### PR TITLE
support building ARM image and handle response from EventListener whose version is above v0.15.0

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push
@@ -39,5 +41,6 @@ jobs:
         with:
           context: .
           file: ./build/${{ matrix.components }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/pkg/cluster/tekton/tekton_run.go
+++ b/pkg/cluster/tekton/tekton_run.go
@@ -43,7 +43,9 @@ func (t *Tekton) CreatePipelineRun(ctx context.Context, pr *PipelineRun) (eventI
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusCreated {
+	// From Tekton Trigger v0.15.0, the EventListener will always respond with a 202 Accepted response code.
+	// Please refer: https://github.com/tektoncd/triggers/releases/tag/v0.15.0.
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 		message := common.Response(ctx, resp)
 		return "", perror.Wrapf(herrors.ErrHTTPRespNotAsExpected, "statusCode = %d, message = %s", resp.StatusCode, message)
 	}


### PR DESCRIPTION
Ready to bump Tekton Trigger version to v0.17.0 to solve the problem that EventListener cannot be deleted in helm uninstallation because of `finalizer`, see: https://github.com/tektoncd/triggers/pull/1244