### PR TITLE
Fix create cluster v2

### DIFF
--- a/core/controller/cluster/controller_basic_v2.go
+++ b/core/controller/cluster/controller_basic_v2.go
@@ -139,7 +139,8 @@ func (c *controller) CreateClusterV2(ctx context.Context, applicationID uint, en
 	}
 
 	// 7. get templateRelease
-	tr, err := c.templateReleaseMgr.GetByTemplateNameAndRelease(ctx, r.TemplateInfo.Name, r.TemplateInfo.Release)
+	tr, err := c.templateReleaseMgr.GetByTemplateNameAndRelease(ctx,
+		buildTemplateInfo.TemplateInfo.Name, buildTemplateInfo.TemplateInfo.Release)
 	if err != nil {
 		return nil, err
 	}
@@ -158,8 +159,8 @@ func (c *controller) CreateClusterV2(ctx context.Context, applicationID uint, en
 		BaseParams: &gitrepo.BaseParams{
 			ClusterID:           clusterResp.ID,
 			Cluster:             clusterResp.Name,
-			PipelineJSONBlob:    r.BuildConfig,
-			ApplicationJSONBlob: r.TemplateConfig,
+			PipelineJSONBlob:    buildTemplateInfo.BuildConfig,
+			ApplicationJSONBlob: buildTemplateInfo.TemplateConfig,
 			TemplateRelease:     tr,
 			Application:         application,
 			Environment:         environment,
@@ -222,7 +223,7 @@ func (c *controller) CreateClusterV2(ctx context.Context, applicationID uint, en
 		log.Warningf(ctx, "failed to create event, err: %s", err.Error())
 	}
 
-	// 12. customize response
+	// 13. customize response
 	return ret, nil
 }
 
@@ -529,12 +530,11 @@ func (c *controller) customizeCreateReqBuildTemplateInfo(ctx context.Context, r 
 
 	var appGitRepoFile *appgitrepo.GetResponse
 	var err error
-	if (r.BuildConfig != nil || r.TemplateInfo != nil) && mergePatch {
-		appGitRepoFile, err = c.applicationGitRepo.GetApplication(ctx, application.Name, environment)
-		if err != nil {
-			return nil, err
-		}
+	appGitRepoFile, err = c.applicationGitRepo.GetApplication(ctx, application.Name, environment)
+	if err != nil {
+		return nil, err
 	}
+
 	if r.BuildConfig != nil {
 		if mergePatch {
 			buildTemplateInfo.BuildConfig, err = mergemap.Merge(appGitRepoFile.BuildConf, r.BuildConfig)

--- a/core/controller/cluster/controller_test.go
+++ b/core/controller/cluster/controller_test.go
@@ -1320,6 +1320,12 @@ func testV2(t *testing.T) {
 		cd:                   mockCd,
 		eventMgr:             manager.EventManager,
 	}
+	applicationGitRepo.EXPECT().GetApplication(gomock.Any(), applicationName, gomock.Any()).
+		Return(&appgitrepo.GetResponse{
+			Manifest:     nil,
+			BuildConf:    pipelineJSONBlob,
+			TemplateConf: applicationJSONBlob,
+		}, nil).Times(1)
 	clusterGitRepo.EXPECT().CreateCluster(ctx, gomock.Any()).Return(nil).Times(1)
 
 	createClusterName := "app-cluster2"

--- a/core/middleware/region/region.go
+++ b/core/middleware/region/region.go
@@ -19,7 +19,7 @@ import (
 )
 
 // http params for create cluster api
-var _urlPattern = regexp.MustCompile(`/apis/core/v1/applications/(\d+)/clusters`)
+var _urlPattern = regexp.MustCompile(`/apis/core/v[12]/applications/(\d+)/clusters`)
 
 const (
 	_method     = http.MethodPost

--- a/core/middleware/region/region.go
+++ b/core/middleware/region/region.go
@@ -44,7 +44,8 @@ func Middleware(param *param.Param, applicationRegionCtl applicationregion.Contr
 			return
 		}
 		// scope format is: {environment}/{region}
-		scope := c.Request.URL.Query().Get(_scopeParam)
+		query := c.Request.URL.Query()
+		scope := query.Get(_scopeParam)
 		params := strings.Split(scope, "/")
 		// invalid scope
 		if scope == "" || len(params) > 2 {
@@ -72,7 +73,8 @@ func Middleware(param *param.Param, applicationRegionCtl applicationregion.Contr
 			return
 		}
 
-		c.Request.URL.RawQuery = fmt.Sprintf("%v=%v/%v", _scopeParam, environment, r)
+		query.Set(_scopeParam, fmt.Sprintf("%v/%v", environment, r))
+		c.Request.URL.RawQuery = query.Encode()
 		c.Next()
 	}, skippers...)
 }

--- a/mock/pkg/cluster/manager/manager.go
+++ b/mock/pkg/cluster/manager/manager.go
@@ -207,18 +207,3 @@ func (mr *MockManagerMockRecorder) UpdateByID(ctx, id, cluster interface{}) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateByID", reflect.TypeOf((*MockManager)(nil).UpdateByID), ctx, id, cluster)
 }
-
-// UpdateTemplateByID mocks base method.
-func (m *MockManager) UpdateTemplateByID(ctx context.Context, id uint, template, release string) (*models.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTemplateByID", ctx, id, template, release)
-	ret0, _ := ret[0].(*models.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateTemplateByID indicates an expected call of UpdateTemplateByID.
-func (mr *MockManagerMockRecorder) UpdateTemplateByID(ctx, id, template, release interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplateByID", reflect.TypeOf((*MockManager)(nil).UpdateTemplateByID), ctx, id, template, release)
-}


### PR DESCRIPTION
1. add default value when region in param scope is empty in CreateClusterV2 API, and no longer override query params when matching default region
2. fix some panic caused by nil point