### PR TITLE
feat: listening events from kubernetes

### DIFF
--- a/core/cmd/cmd.go
+++ b/core/cmd/cmd.go
@@ -105,7 +105,6 @@ import (
 	"github.com/horizoncd/horizon/core/middleware"
 	"github.com/horizoncd/horizon/core/middleware/auth"
 	"github.com/horizoncd/horizon/core/middleware/requestid"
-	"github.com/horizoncd/horizon/core/operater"
 	gitlablib "github.com/horizoncd/horizon/lib/gitlab"
 	"github.com/horizoncd/horizon/pkg/cd"
 	"github.com/horizoncd/horizon/pkg/environment/service"
@@ -117,6 +116,7 @@ import (
 	"github.com/horizoncd/horizon/pkg/jobs/grafanasync"
 	"github.com/horizoncd/horizon/pkg/jobs/k8sevent"
 	jobwebhook "github.com/horizoncd/horizon/pkg/jobs/webhook"
+	"github.com/horizoncd/horizon/pkg/regioninformers"
 	"github.com/horizoncd/horizon/pkg/token/generator"
 	tokenservice "github.com/horizoncd/horizon/pkg/token/service"
 	tokenstorage "github.com/horizoncd/horizon/pkg/token/storage"
@@ -437,7 +437,7 @@ func Init(ctx context.Context, flags *Flags, coreConfig *config.Config) {
 	}
 
 	grafanaService := grafana.NewService(coreConfig.GrafanaConfig, manager, client)
-	regionInformers := operater.NewRegionInformers(manager.RegionMgr, 0)
+	regionInformers := regioninformers.NewRegionInformers(manager.RegionMgr, 0)
 	regionInformers.Register(workload.Resources...)
 	parameter := &param.Param{
 		Manager:              manager,

--- a/core/common/const.go
+++ b/core/common/const.go
@@ -23,13 +23,19 @@ const (
 	TemplateRelease = "templateRelease"
 	TagSelector     = "tagSelector"
 
-	Offset    = "offset"
+	// Offset should be type int
+	Offset = "offset"
+	// Limit should be type int
 	Limit     = "limit"
 	StartID   = "startID"
 	EndID     = "endID"
 	EventType = "eventType"
+	WebhookID = "webhookID"
 	CreatedAt = "createdAt"
 	Enabled   = "enabled"
+	Orphaned  = "orphaned"
+	OrderBy   = "orderBy"
+	ReqID     = "reqID"
 
 	DefaultPageNumber = 1
 	DefaultPageSize   = 20

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -21,12 +21,14 @@ import (
 	"github.com/horizoncd/horizon/pkg/config/argocd"
 	"github.com/horizoncd/horizon/pkg/config/authenticate"
 	"github.com/horizoncd/horizon/pkg/config/autofree"
+	"github.com/horizoncd/horizon/pkg/config/clean"
 	"github.com/horizoncd/horizon/pkg/config/db"
 	"github.com/horizoncd/horizon/pkg/config/eventhandler"
 	"github.com/horizoncd/horizon/pkg/config/git"
 	"github.com/horizoncd/horizon/pkg/config/gitlab"
 	"github.com/horizoncd/horizon/pkg/config/grafana"
 	"github.com/horizoncd/horizon/pkg/config/job"
+	"github.com/horizoncd/horizon/pkg/config/k8sevent"
 	"github.com/horizoncd/horizon/pkg/config/oauth"
 	"github.com/horizoncd/horizon/pkg/config/pprof"
 	"github.com/horizoncd/horizon/pkg/config/redis"
@@ -63,6 +65,8 @@ type Config struct {
 	CodeGitRepos           []*git.Repo             `yaml:"gitRepos"`
 	TokenConfig            token.Config            `yaml:"tokenConfig"`
 	TemplateUpgradeMapper  template.UpgradeMapper  `yaml:"templateUpgradeMapper"`
+	KubernetesEvent        k8sevent.Config         `yaml:"kubernetesEvent"`
+	Clean                  clean.Config            `yaml:"clean"`
 }
 
 func LoadConfig(configFilePath string) (*Config, error) {

--- a/core/controller/cluster/controller_operation.go
+++ b/core/controller/cluster/controller_operation.go
@@ -450,6 +450,7 @@ func (c *controller) ExecuteAction(ctx context.Context, clusterID uint,
 		Action:       action,
 		GVR:          gvr,
 		ResourceName: cluster.Name,
+		ClusterID:    clusterID,
 	})
 }
 

--- a/core/controller/cluster/controller_status.go
+++ b/core/controller/cluster/controller_status.go
@@ -534,6 +534,7 @@ func (c *controller) GetStep(ctx context.Context, clusterID uint) (resp *GetStep
 			Replicas:     steps.Replicas,
 			ManualPaused: steps.ManualPaused,
 			AutoPromote:  steps.AutoPromote,
+			Extra:        steps.Extra,
 		}
 	} else {
 		resp = &GetStepResponse{

--- a/core/controller/cluster/models_status.go
+++ b/core/controller/cluster/models_status.go
@@ -79,9 +79,10 @@ type GetResourceTreeResponse struct {
 }
 
 type GetStepResponse struct {
-	Index        int   `json:"index"`
-	Total        int   `json:"total"`
-	Replicas     []int `json:"replicas"`
-	ManualPaused bool  `json:"manualPaused"`
-	AutoPromote  bool  `json:"autoPromote"`
+	Index        int     `json:"index"`
+	Total        int     `json:"total"`
+	Replicas     []int   `json:"replicas"`
+	ManualPaused bool    `json:"manualPaused"`
+	AutoPromote  bool    `json:"autoPromote"`
+	Extra        *string `json:"extra"`
 }

--- a/core/controller/webhook/controller.go
+++ b/core/controller/webhook/controller.go
@@ -191,7 +191,17 @@ func (c *controller) ListWebhookLogs(ctx context.Context, wID uint,
 		}
 	}
 
-	webhookLogs, total, err := c.webhookMgr.ListWebhookLogs(ctx, wID, query, resources)
+	if query == nil {
+		query = &q.Query{}
+	}
+	if query.Keywords == nil {
+		query.Keywords = make(q.KeyWords)
+	}
+	query.Keywords[common.WebhookID] = wID
+	query.Keywords[common.Offset] = query.Offset()
+	query.Keywords[common.Limit] = query.Limit()
+	query.Keywords[common.OrderBy] = "e.created_at desc"
+	webhookLogs, total, err := c.webhookMgr.ListWebhookLogs(ctx, query, resources)
 	if err != nil {
 		return nil, total, err
 	}

--- a/core/operater/informer.go
+++ b/core/operater/informer.go
@@ -1,0 +1,486 @@
+package operater
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	herrors "github.com/horizoncd/horizon/core/errors"
+	"github.com/horizoncd/horizon/pkg/region/manager"
+	"github.com/horizoncd/horizon/pkg/region/models"
+	"github.com/horizoncd/horizon/pkg/util/log"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type RegionClient struct {
+	regionID         uint
+	watched          map[schema.GroupVersionResource]informers.GenericInformer
+	dynamicWatched   map[schema.GroupVersionResource]informers.GenericInformer
+	factory          informers.SharedInformerFactory
+	dynamicFactory   dynamicinformer.DynamicSharedInformerFactory
+	clientset        kubernetes.Interface
+	dynamicClientset dynamic.Interface
+	handlers         map[int]struct{}
+	mapper           meta.RESTMapper
+	stopCh           chan struct{}
+	lastUpdated      time.Time
+}
+
+type Resource struct {
+	MakeHandler func(uint, <-chan struct{}) (cache.ResourceEventHandler, error)
+	GVR         schema.GroupVersionResource
+}
+
+type Target struct {
+	Resource
+	Regions map[uint]struct{}
+}
+
+// RegionInformers is a collection of informer factories for each region
+type RegionInformers struct {
+	regionMgr manager.Manager
+
+	defaultResync time.Duration
+
+	handlers []Resource
+
+	// mu protects factories, lastUpdated and stopChanMap
+	mu      sync.RWMutex
+	clients map[uint]*RegionClient
+}
+
+// NewRegionInformers is called when initializing
+func NewRegionInformers(regionMgr manager.Manager, defaultResync time.Duration) *RegionInformers {
+	f := RegionInformers{
+		regionMgr:     regionMgr,
+		clients:       make(map[uint]*RegionClient),
+		handlers:      make([]Resource, 0, 16),
+		defaultResync: defaultResync,
+	}
+	regions, err := f.listRegion(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	wg := sync.WaitGroup{}
+	for _, region := range regions {
+		wg.Add(1)
+		go func(region *models.Region) {
+			log.Debugf(context.Background(), "Creating informer for region %s", region.Name)
+			defer wg.Done()
+			if err := f.NewRegionInformers(region); err != nil {
+				log.Errorf(context.Background(), "Failed to create informer for region %s(%d): %v", region.Name, region.ID, err)
+			}
+		}(region)
+	}
+	wg.Wait()
+	return &f
+}
+
+func (f *RegionInformers) NewRegionInformers(region *models.Region) error {
+	if region == nil {
+		return nil
+	}
+
+	config, err := clientcmd.NewClientConfigFromBytes([]byte(region.Certificate))
+	if err != nil {
+		return err
+	}
+	restConfig, err := config.ClientConfig()
+	if err != nil {
+		return err
+	}
+
+	clientSet, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	factory := informers.NewSharedInformerFactory(clientSet, f.defaultResync)
+
+	dynamicClientSet, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	dynamicFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClientSet, f.defaultResync)
+
+	resources, err := restmapper.GetAPIGroupResources(clientSet.Discovery())
+	if err != nil {
+		return err
+	}
+
+	mapper := restmapper.NewDiscoveryRESTMapper(resources)
+
+	stopCh := make(chan struct{}, 1)
+	client := RegionClient{
+		regionID:         region.ID,
+		watched:          make(map[schema.GroupVersionResource]informers.GenericInformer),
+		dynamicWatched:   make(map[schema.GroupVersionResource]informers.GenericInformer),
+		factory:          factory,
+		dynamicFactory:   dynamicFactory,
+		clientset:        clientSet,
+		dynamicClientset: dynamicClientSet,
+		handlers:         make(map[int]struct{}),
+		mapper:           mapper,
+		stopCh:           stopCh,
+		lastUpdated:      region.UpdatedAt,
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.clients[region.ID] = &client
+
+	f.registerHandler(&client)
+	return nil
+}
+
+func (f *RegionInformers) DeleteRegionInformer(regionID uint) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	client, ok := f.clients[regionID]
+	if !ok {
+		return
+	}
+	close(client.stopCh)
+	delete(f.clients, regionID)
+}
+
+// listRegion list all regions which are not disabled
+func (f *RegionInformers) listRegion(ctx context.Context) ([]*models.Region, error) {
+	regions, err := f.regionMgr.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// offset := 0
+	// for i := range regions {
+	// 	if regions[i].Disabled {
+	// 		offset++
+	// 		continue
+	// 	}
+	// 	regions[i-offset] = regions[i]
+	// }
+	// return regions[:len(regions)-offset], nil
+	return regions, nil
+}
+
+// WatchDB blocks until ctx is done, and watch the database for region changes
+func (f *RegionInformers) WatchDB(ctx context.Context, pollInterval time.Duration) {
+	err := wait.Poll(pollInterval, 0, func() (done bool, err error) {
+		select {
+		case <-ctx.Done():
+			return true, nil
+		default:
+		}
+
+		f.watchDB()
+		return false, nil
+	})
+	if err != nil {
+		log.Errorf(ctx, "WatchDB polling error: %v", err)
+	}
+}
+
+// watchDB watches the database and fetches regions diff with the cache
+func (f *RegionInformers) watchDB() {
+	created, updated, deleted, err := f.diffRegion()
+	if err != nil {
+		log.Errorf(context.Background(), "diffRegion error: %v", err)
+		return
+	}
+
+	created = append(created, updated...)
+	deleted = append(deleted, updated...)
+
+	for _, region := range deleted {
+		f.DeleteRegionInformer(region.ID)
+	}
+
+	for _, region := range created {
+		if err := f.NewRegionInformers(region); err != nil {
+			log.Errorf(context.Background(), "NewRegionInformers error: %v", err)
+		}
+	}
+}
+
+func (f *RegionInformers) diffRegion() ([]*models.Region, []*models.Region, []*models.Region, error) {
+	regions, err := f.listRegion(context.Background())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	created, updated, deleted := make([]*models.Region, 0), make([]*models.Region, 0), make([]*models.Region, 0)
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	regionsID := make(map[uint]*models.Region)
+	for _, region := range regions {
+		regionsID[region.ID] = region
+		if _, ok := f.clients[region.ID]; !ok {
+			created = append(created, region)
+			continue
+		}
+		if region.UpdatedAt.After(f.clients[region.ID].lastUpdated) {
+			updated = append(updated, region)
+		}
+	}
+
+	for regionID := range f.clients {
+		if region, ok := regionsID[regionID]; !ok {
+			deleted = append(deleted, region)
+		}
+	}
+
+	return created, updated, deleted, nil
+}
+
+type ClientSetOperation func(clientset kubernetes.Interface) error
+
+// GetClientSet gets the client for the given region
+// it should have no reference for factory outside RegionInformers
+func (f *RegionInformers) GetClientSet(regionID uint, operation ClientSetOperation) error {
+	if err := f.ensureRegion(regionID); err != nil {
+		return err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return operation(f.clients[regionID].clientset)
+}
+
+type DynamicClientSetOperation func(clientset dynamic.Interface) error
+
+// GetDynamicClientSet gets the dynamic clientset for the given region
+// it should have no reference for factory outside RegionInformers
+func (f *RegionInformers) GetDynamicClientSet(regionID uint, operation DynamicClientSetOperation) error {
+	if err := f.ensureRegion(regionID); err != nil {
+		return err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return operation(f.clients[regionID].dynamicClientset)
+}
+
+func (f *RegionInformers) whetherGVRExist(regionID uint, gvr schema.GroupVersionResource) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	_, ok := f.clients[regionID].watched[gvr]
+	return ok
+}
+
+func (f *RegionInformers) watchGVR(regionID uint, gvr schema.GroupVersionResource) error {
+	f.mu.Lock()
+	client := f.clients[regionID]
+	informer, err := client.factory.ForResource(gvr)
+	if err != nil {
+		return err
+	}
+	client.watched[gvr] = informer
+	f.mu.Unlock()
+
+	client.factory.Start(client.stopCh)
+	client.factory.WaitForCacheSync(client.stopCh)
+	return nil
+}
+
+func (f *RegionInformers) watchDynamicGvr(regionID uint, gvr schema.GroupVersionResource) {
+	f.mu.Lock()
+	client := f.clients[regionID]
+	informer := client.dynamicFactory.ForResource(gvr)
+	client.dynamicWatched[gvr] = informer
+	f.mu.Unlock()
+
+	client.dynamicFactory.Start(client.stopCh)
+	client.dynamicFactory.WaitForCacheSync(client.stopCh)
+}
+
+func (f *RegionInformers) ensureGVR(regionID uint, gvr schema.GroupVersionResource) error {
+	if err := f.ensureRegion(regionID); err != nil {
+		return err
+	}
+
+	if !f.whetherGVRExist(regionID, gvr) {
+		return f.watchGVR(regionID, gvr)
+	}
+	return nil
+}
+
+func (f *RegionInformers) ensureDynamicGVR(regionID uint, gvr schema.GroupVersionResource) {
+	if !f.whetherGVRExist(regionID, gvr) {
+		f.watchDynamicGvr(regionID, gvr)
+	}
+}
+
+type InformerOperation func(informer informers.GenericInformer) error
+
+// GetInformer gets the informer for the given region and gvr
+// it should have no reference for factory outside RegionInformers
+func (f *RegionInformers) GetInformer(regionID uint,
+	gvr schema.GroupVersionResource, operation InformerOperation) error {
+	if err := f.ensureRegion(regionID); err != nil {
+		return err
+	}
+
+	if err := f.ensureGVR(regionID, gvr); err != nil {
+		return err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	informer, err := f.clients[regionID].factory.ForResource(gvr)
+	if err != nil {
+		return err
+	}
+	return operation(informer)
+}
+
+type FactoryOperation func(factory informers.SharedInformerFactory) error
+
+func (f *RegionInformers) GetFactory(regionID uint, operation FactoryOperation) error {
+	if err := f.ensureRegion(regionID); err != nil {
+		return err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return operation(f.clients[regionID].factory)
+}
+
+type DynamicInformerOperation func(informer informers.GenericInformer) error
+
+// GetDynamicInformer gets the informer for the given region and gvr
+// it should have no reference for factory outside RegionInformers
+func (f *RegionInformers) GetDynamicInformer(regionID uint,
+	gvr schema.GroupVersionResource, operation DynamicInformerOperation) error {
+	if err := f.ensureRegion(regionID); err != nil {
+		return err
+	}
+
+	f.ensureDynamicGVR(regionID, gvr)
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return operation(f.clients[regionID].dynamicFactory.ForResource(gvr))
+}
+
+type DynamicFactoryOperation func(factory dynamicinformer.DynamicSharedInformerFactory) error
+
+func (f *RegionInformers) GetDynamicFactory(regionID uint, operation DynamicFactoryOperation) error {
+	if err := f.ensureRegion(regionID); err != nil {
+		return err
+	}
+
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return operation(f.clients[regionID].dynamicFactory)
+}
+
+func (f *RegionInformers) checkExist(regionID uint) bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	_, ok := f.clients[regionID]
+	return ok
+}
+
+// ensureRegion runs the operation if the region exists, otherwise create a new factory
+func (f *RegionInformers) ensureRegion(regionID uint) error {
+	if !f.checkExist(regionID) {
+		region, err := f.regionMgr.GetRegionByID(context.Background(), regionID)
+		if err != nil {
+			return err
+		}
+		return f.NewRegionInformers(region.Region)
+	}
+	return nil
+}
+
+func (f *RegionInformers) Register(handlers ...Resource) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handlers = append(f.handlers, handlers...)
+
+	for _, client := range f.clients {
+		f.registerHandler(client)
+	}
+}
+
+func (f *RegionInformers) registerHandler(client *RegionClient) {
+	for i, handler := range f.handlers {
+		if _, ok := client.handlers[i]; ok {
+			continue
+		}
+		informer := client.dynamicFactory.ForResource(handler.GVR)
+		if handler.MakeHandler != nil {
+			eventHandler, err := handler.MakeHandler(client.regionID, client.stopCh)
+			if err != nil {
+				log.Errorf(context.Background(), "make handler for %s failed: %v", handler.GVR, err)
+				continue
+			}
+			informer.Informer().AddEventHandler(eventHandler)
+		}
+		client.handlers[i] = struct{}{}
+	}
+
+	client.factory.Start(client.stopCh)
+	client.dynamicFactory.Start(client.stopCh)
+}
+
+func (f *RegionInformers) Start(regionIDs ...uint) error {
+	if len(regionIDs) == 0 {
+		regions, err := f.listRegion(context.Background())
+		if err != nil {
+			return err
+		}
+		for _, region := range regions {
+			regionIDs = append(regionIDs, region.ID)
+		}
+	}
+
+	for _, regionID := range regionIDs {
+		if err := f.ensureRegion(regionID); err != nil {
+			return err
+		}
+	}
+
+	for _, regionID := range regionIDs {
+		func() {
+			f.mu.RLock()
+			defer f.mu.RUnlock()
+
+			client := f.clients[regionID]
+			stopCh := client.stopCh
+			client.dynamicFactory.Start(stopCh)
+			client.factory.Start(stopCh)
+		}()
+	}
+	return nil
+}
+
+func (f *RegionInformers) GVK2GVR(regionID uint, GVK schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	client, ok := f.clients[regionID]
+	if !ok {
+		return schema.GroupVersionResource{},
+			herrors.NewErrNotFound(herrors.RegionInDB, fmt.Sprintf("region %d", regionID))
+	}
+
+	mapping, err := client.mapper.RESTMapping(GVK.GroupKind(), GVK.Version)
+	if err != nil {
+		return schema.GroupVersionResource{},
+			herrors.NewErrNotFound(herrors.ResourceInK8S, fmt.Sprintf("mapping for %s: %s", GVK, err))
+	}
+	return mapping.Resource, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rbcervilla/redisstore/v8 v8.1.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1528,6 +1528,8 @@ github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShE
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron v1.1.0 h1:jk4/Hud3TTdcrJgUOBgsqrZBarcxl6ADIjSC2iniwLY=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/pkg/cd/cd.go
+++ b/pkg/cd/cd.go
@@ -29,12 +29,12 @@ import (
 	kubeutil "github.com/argoproj/gitops-engine/pkg/utils/kube"
 	"github.com/horizoncd/horizon/core/common"
 	herrors "github.com/horizoncd/horizon/core/errors"
-	"github.com/horizoncd/horizon/core/operater"
 	"github.com/horizoncd/horizon/pkg/argocd"
 	"github.com/horizoncd/horizon/pkg/cluster/gitrepo"
 	"github.com/horizoncd/horizon/pkg/cluster/kubeclient"
 	argocdconf "github.com/horizoncd/horizon/pkg/config/argocd"
 	perror "github.com/horizoncd/horizon/pkg/errors"
+	"github.com/horizoncd/horizon/pkg/regioninformers"
 	"github.com/horizoncd/horizon/pkg/util/kube"
 	"github.com/horizoncd/horizon/pkg/util/log"
 	"github.com/horizoncd/horizon/pkg/util/wlog"
@@ -91,13 +91,13 @@ type CD interface {
 
 type cd struct {
 	kubeClientFty     kubeclient.Factory
-	informerFactories *operater.RegionInformers
+	informerFactories *regioninformers.RegionInformers
 	factory           argocd.Factory
 	clusterGitRepo    gitrepo.ClusterGitRepo
 	targetRevision    string
 }
 
-func NewCD(informerFactories *operater.RegionInformers, clusterGitRepo gitrepo.ClusterGitRepo,
+func NewCD(informerFactories *regioninformers.RegionInformers, clusterGitRepo gitrepo.ClusterGitRepo,
 	argoCDMapper argocdconf.Mapper, targetRevision string) CD {
 	return &cd{
 		kubeClientFty:     kubeclient.Fty,

--- a/pkg/cd/cd.go
+++ b/pkg/cd/cd.go
@@ -90,7 +90,7 @@ type CD interface {
 }
 
 type cd struct {
-	kubeClientFty     kubeclient.Factory
+	kubeClientFactory kubeclient.Factory
 	informerFactories *regioninformers.RegionInformers
 	factory           argocd.Factory
 	clusterGitRepo    gitrepo.ClusterGitRepo
@@ -100,7 +100,7 @@ type cd struct {
 func NewCD(informerFactories *regioninformers.RegionInformers, clusterGitRepo gitrepo.ClusterGitRepo,
 	argoCDMapper argocdconf.Mapper, targetRevision string) CD {
 	return &cd{
-		kubeClientFty:     kubeclient.Fty,
+		kubeClientFactory: kubeclient.Fty,
 		informerFactories: informerFactories,
 		factory:           argocd.NewFactory(argoCDMapper),
 		clusterGitRepo:    clusterGitRepo,
@@ -247,7 +247,7 @@ func (c *cd) GetStep(ctx context.Context, params *GetStepParams) (*Step, error) 
 	const op = "cd: get step"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	_, kubeClient, err := c.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
+	_, kubeClient, err := c.kubeClientFactory.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
 	if err != nil {
 		return nil, err
 	}
@@ -355,7 +355,7 @@ func (c *cd) GetClusterState(ctx context.Context,
 		return status, nil
 	}
 
-	_, kubeClient, err := c.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
+	_, kubeClient, err := c.kubeClientFactory.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
 	if err != nil {
 		return nil, err
 	}
@@ -407,7 +407,7 @@ func (c *cd) GetClusterStateV1(ctx context.Context,
 		return nil, err
 	}
 
-	_, kubeClient, err := c.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
+	_, kubeClient, err := c.kubeClientFactory.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +572,7 @@ func (c *cd) GetPodEvents(ctx context.Context,
 	const op = "cd: get cluster pod events"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	_, kubeClient, err := c.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
+	_, kubeClient, err := c.kubeClientFactory.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cd/cd.go
+++ b/pkg/cd/cd.go
@@ -303,6 +303,7 @@ func (c *cd) GetStep(ctx context.Context, params *GetStepParams) (*Step, error) 
 		Replicas:     step.Replicas,
 		ManualPaused: step.ManualPaused,
 		AutoPromote:  step.AutoPromote,
+		Extra:        step.Extra,
 	}, nil
 }
 

--- a/pkg/cd/k8sutil.go
+++ b/pkg/cd/k8sutil.go
@@ -17,21 +17,27 @@ package cd
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 	"time"
 
 	applicationV1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	"github.com/horizoncd/horizon/core/common"
 	herrors "github.com/horizoncd/horizon/core/errors"
-	"github.com/horizoncd/horizon/pkg/cluster/kubeclient"
+	"github.com/horizoncd/horizon/core/operater"
 	perror "github.com/horizoncd/horizon/pkg/errors"
+	eventmanager "github.com/horizoncd/horizon/pkg/event/manager"
+	eventmodels "github.com/horizoncd/horizon/pkg/event/models"
 	"github.com/horizoncd/horizon/pkg/util/kube"
 	"github.com/horizoncd/horizon/pkg/util/log"
 	"github.com/horizoncd/horizon/pkg/util/wlog"
 	"github.com/horizoncd/horizon/pkg/workload"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
 
 //go:generate mockgen -source=$GOFILE -destination=../../mock/pkg/cd/k8sutil_mock.go -package=mock_cd
@@ -45,64 +51,65 @@ type K8sUtil interface {
 }
 
 type util struct {
-	kubeClientFty kubeclient.Factory
+	informerFactories *operater.RegionInformers
+	eventMgr          eventmanager.Manager
 }
 
-func NewK8sUtil() K8sUtil {
+func NewK8sUtil(factories *operater.RegionInformers, mgr eventmanager.Manager) K8sUtil {
 	return &util{
-		kubeClientFty: kubeclient.Fty,
+		informerFactories: factories,
+		eventMgr:          mgr,
 	}
 }
 
 func (e *util) DeletePods(ctx context.Context,
 	params *DeletePodsParams) (map[string]OperationResult, error) {
 	result := map[string]OperationResult{}
-	_, kubeClient, err := e.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
-	if err != nil {
-		return result, err
-	}
 
-	for _, pod := range params.Pods {
-		err = kube.DeletePods(ctx, kubeClient.Basic, params.Namespace, pod)
-		if err != nil {
-			result[pod] = OperationResult{
-				Result: false,
-				Error:  err,
+	_ = e.informerFactories.GetClientSet(params.RegionEntity.ID, func(clientset kubernetes.Interface) error {
+		for _, pod := range params.Pods {
+			err := kube.DeletePods(ctx, clientset, params.Namespace, pod)
+			if err != nil {
+				result[pod] = OperationResult{
+					Result: false,
+					Error:  err,
+				}
+				continue
 			}
-			continue
+			result[pod] = OperationResult{
+				Result: true,
+			}
 		}
-		result[pod] = OperationResult{
-			Result: true,
-		}
-	}
+		return nil
+	})
 
 	return result, nil
 }
 
 func (e *util) GetContainerLog(ctx context.Context, params *GetContainerLogParams) (<-chan string, error) {
-	_, kubeClient, err := e.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
+	var logC = make(chan string)
+	err := e.informerFactories.GetClientSet(params.RegionEntity.ID, func(clientset kubernetes.Interface) error {
+		podLogRequest := clientset.CoreV1().Pods(params.Namespace).GetLogs(params.Pod, &corev1.PodLogOptions{
+			Container:  params.Container,
+			TailLines:  &params.TailLines,
+			Timestamps: true,
+		})
+		stream, err := podLogRequest.Stream(context.TODO())
+		if err != nil {
+			return herrors.NewErrGetFailed(herrors.PodLogsInK8S, err.Error())
+		}
+
+		go func() {
+			defer stream.Close()
+			defer close(logC)
+			parseLogsStream(stream, logC)
+		}()
+		return nil
+	})
+
 	if err != nil {
 		return nil, err
 	}
-
-	podLogRequest := kubeClient.Basic.CoreV1().Pods(params.Namespace).GetLogs(params.Pod, &corev1.PodLogOptions{
-		Container:  params.Container,
-		TailLines:  &params.TailLines,
-		Timestamps: true,
-	})
-	stream, err := podLogRequest.Stream(context.TODO())
-	if err != nil {
-		return nil, herrors.NewErrGetFailed(herrors.PodLogsInK8S, err.Error())
-	}
-
-	logC := make(chan string)
-
-	go func() {
-		defer stream.Close()
-		defer close(logC)
-		parseLogsStream(stream, logC)
-	}()
-
 	return logC, nil
 }
 
@@ -139,46 +146,66 @@ func parseLogsStream(stream io.ReadCloser, ch chan string) {
 
 func (e *util) ExecuteAction(ctx context.Context,
 	params *ExecuteActionParams) (err error) {
-	_, kubeClient, err := e.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
-	if err != nil {
-		return herrors.NewErrGetFailed(herrors.K8SClient,
-			fmt.Sprintf("failed to get kube client for %s", params.RegionEntity.Server))
-	}
-	un, err := kubeClient.Dynamic.Resource(params.GVR).Namespace(params.Namespace).
-		Get(ctx, params.ResourceName, metav1.GetOptions{})
-	if err != nil {
-		return herrors.NewErrGetFailed(herrors.ResourceInK8S,
-			fmt.Sprintf("failed to get %s(%s)", params.ResourceName, params.GVR.String()))
-	}
-
-	workload.LoopAbilities(func(workload workload.Workload) bool {
-		if workload.MatchGK(un.GroupVersionKind().GroupKind()) {
-			un, err = workload.Action(params.Action, un)
-			return false
+	err = e.informerFactories.GetDynamicClientSet(params.RegionEntity.ID, func(clientset dynamic.Interface) error {
+		un, err := clientset.Resource(params.GVR).Namespace(params.Namespace).
+			Get(ctx, params.ResourceName, metav1.GetOptions{})
+		if err != nil {
+			return herrors.NewErrGetFailed(herrors.ResourceInK8S,
+				fmt.Sprintf("failed to get %s(%s)", params.ResourceName, params.GVR.String()))
 		}
-		return true
-	})
-	if err != nil {
-		return perror.Wrapf(err, "failed to execute '%s' for %s(%s)",
-			params.Action, params.ResourceName, params.GVR.String())
-	}
 
-	un, err = kubeClient.Dynamic.Resource(params.GVR).Namespace(params.Namespace).
-		Update(ctx, un, metav1.UpdateOptions{})
-	log.Debugf(ctx, "update %s(%s) with %s: %v", params.ResourceName,
-		params.GVR.String(), params.Action, un)
+		workload.LoopAbilities(func(workload workload.Workload) bool {
+			if workload.MatchGK(un.GroupVersionKind().GroupKind()) {
+				un, err = workload.Action(params.Action, un)
+				return false
+			}
+			return true
+		})
+		if err != nil {
+			return perror.Wrapf(err, "failed to execute '%s' for %s(%s)",
+				params.Action, params.ResourceName, params.GVR.String())
+		}
+
+		un, err = clientset.Resource(params.GVR).Namespace(params.Namespace).
+			Update(ctx, un, metav1.UpdateOptions{})
+		log.Debugf(ctx, "update %s(%s) with %s: %v", params.ResourceName,
+			params.GVR.String(), params.Action, un)
+		if err != nil {
+			return herrors.NewErrUpdateFailed(herrors.ResourceInK8S,
+				fmt.Sprintf("failed to update gvr(%s), ns(%s), name(%s)",
+					params.GVR.String(), params.Namespace, un.GetName()))
+		}
+		if err != nil {
+			bts, err := json.Marshal(map[string]interface{}{
+				"action":       params.Action,
+				"gvr":          params.GVR.String(),
+				"resourceName": params.Namespace,
+			})
+			if err != nil {
+				log.Warningf(ctx, "failed to marshal event extra, err: %s", err.Error())
+			}
+			extra := string(bts)
+			if _, err = e.eventMgr.CreateEvent(ctx, &eventmodels.Event{
+				EventSummary: eventmodels.EventSummary{
+					ResourceType: common.ResourceApplication,
+					EventType:    eventmodels.ClusterRestarted,
+					ResourceID:   params.ClusterID,
+					Extra:        &extra,
+				},
+			}); err != nil {
+				log.Warningf(ctx, "failed to create event, err: %s", err.Error())
+			}
+		}
+		return err
+	})
 
 	return err
 }
 
 func (e *util) GetPodContainers(ctx context.Context,
 	params *GetPodParams) (containers []ContainerDetail, err error) {
-	_, kubeClient, err := e.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
-	if err != nil {
-		return nil, err
-	}
+	pod, err := e.GetPod(ctx, params)
 
-	pod, err := kube.GetPod(ctx, kubeClient.Basic, params.Namespace, params.Pod)
 	if err != nil {
 		return nil, err
 	}
@@ -188,39 +215,36 @@ func (e *util) GetPodContainers(ctx context.Context,
 
 func (e *util) GetPod(ctx context.Context,
 	params *GetPodParams) (pod *corev1.Pod, err error) {
-	_, kubeClient, err := e.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
+	err = e.informerFactories.GetClientSet(params.RegionEntity.ID, func(clientset kubernetes.Interface) error {
+		pod, err = kube.GetPod(ctx, clientset, params.Namespace, params.Pod)
+		return err
+	})
+
 	if err != nil {
 		return nil, err
 	}
-
-	pod, err = kube.GetPod(ctx, kubeClient.Basic, params.Namespace, params.Pod)
-	if err != nil {
-		return nil, err
-	}
-
 	return pod, nil
 }
 
-func (e *util) Exec(ctx context.Context, params *ExecParams) (_ map[string]ExecResp, err error) {
+func (e *util) Exec(ctx context.Context, params *ExecParams) (resp map[string]ExecResp, err error) {
 	const op = "cd: shell exec"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	config, kubeClient, err := e.kubeClientFty.GetByK8SServer(params.RegionEntity.Server, params.RegionEntity.Certificate)
-	if err != nil {
-		return nil, err
-	}
-	containers := make([]kube.ContainerRef, 0)
-	for _, pod := range params.PodList {
-		containers = append(containers, kube.ContainerRef{
-			Config:        config,
-			KubeClientset: kubeClient.Basic,
-			Namespace:     params.Namespace,
-			Pod:           pod,
-			Container:     params.Cluster,
-		})
-	}
+	_ = e.informerFactories.GetClientSet(params.RegionEntity.ID, func(clientset kubernetes.Interface) error {
+		containers := make([]kube.ContainerRef, 0)
+		for _, pod := range params.PodList {
+			containers = append(containers, kube.ContainerRef{
+				KubeClientset: clientset,
+				Namespace:     params.Namespace,
+				Pod:           pod,
+				Container:     params.Cluster,
+			})
+		}
+		resp = executeCommandInPods(ctx, containers, params.Commands, nil)
+		return nil
+	})
 
-	return executeCommandInPods(ctx, containers, params.Commands, nil), nil
+	return resp, nil
 }
 
 // TraverseOperator stops if result is false

--- a/pkg/cd/k8sutil.go
+++ b/pkg/cd/k8sutil.go
@@ -26,10 +26,10 @@ import (
 	applicationV1alpha1 "github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	"github.com/horizoncd/horizon/core/common"
 	herrors "github.com/horizoncd/horizon/core/errors"
-	"github.com/horizoncd/horizon/core/operater"
 	perror "github.com/horizoncd/horizon/pkg/errors"
 	eventmanager "github.com/horizoncd/horizon/pkg/event/manager"
 	eventmodels "github.com/horizoncd/horizon/pkg/event/models"
+	"github.com/horizoncd/horizon/pkg/regioninformers"
 	"github.com/horizoncd/horizon/pkg/util/kube"
 	"github.com/horizoncd/horizon/pkg/util/log"
 	"github.com/horizoncd/horizon/pkg/util/wlog"
@@ -51,11 +51,11 @@ type K8sUtil interface {
 }
 
 type util struct {
-	informerFactories *operater.RegionInformers
+	informerFactories *regioninformers.RegionInformers
 	eventMgr          eventmanager.Manager
 }
 
-func NewK8sUtil(factories *operater.RegionInformers, mgr eventmanager.Manager) K8sUtil {
+func NewK8sUtil(factories *regioninformers.RegionInformers, mgr eventmanager.Manager) K8sUtil {
 	return &util{
 		informerFactories: factories,
 		eventMgr:          mgr,

--- a/pkg/cd/types.go
+++ b/pkg/cd/types.go
@@ -135,6 +135,7 @@ type ExecuteActionParams struct {
 	Action       string
 	GVR          schema.GroupVersionResource
 	ResourceName string
+	ClusterID    uint
 }
 
 type ClusterAutoPromoteParams struct {

--- a/pkg/cd/types.go
+++ b/pkg/cd/types.go
@@ -249,11 +249,12 @@ type ClusterState struct {
 }
 
 type Step struct {
-	Index        int   `json:"index"`
-	Total        int   `json:"total"`
-	Replicas     []int `json:"replicas"`
-	ManualPaused bool  `json:"manualPaused"`
-	AutoPromote  bool  `json:"autoPromote"`
+	Index        int     `json:"index"`
+	Total        int     `json:"total"`
+	Replicas     []int   `json:"replicas"`
+	ManualPaused bool    `json:"manualPaused"`
+	AutoPromote  bool    `json:"autoPromote"`
+	Extra        *string `json:"extra"`
 }
 
 // ClusterVersion version information

--- a/pkg/config/clean/config.go
+++ b/pkg/config/clean/config.go
@@ -1,0 +1,32 @@
+package clean
+
+import "time"
+
+type WebhookLogCleanRule struct {
+	TTL time.Duration `yaml:"ttl"`
+}
+
+type EventCleanRule struct {
+	EventType string        `yaml:"eventType"`
+	TTL       time.Duration `yaml:"ttl"`
+
+	// APIVersion only take effect when EventType is "clusters_kubernetes_event"
+	APIVersion string `yaml:"apiVersion"`
+	// Kind only take effect when EventType is "clusters_kubernetes_event"
+	Kind string `yaml:"kind"`
+	// Name only take effect when EventType is "clusters_kubernetes_event"
+	Name string `yaml:"name"`
+	// Namespace only take effect when EventType is "clusters_kubernetes_event"
+	Namespace string `yaml:"namespace"`
+	// Reason only take effect when EventType is "clusters_kubernetes_event"
+	Reason string `yaml:"reason"`
+}
+
+type Config struct {
+	Batch int `yaml:"batch"`
+	// TimeToRun is a cron expression with seconds precision
+	TimeToRun string `yaml:"timeToRun"`
+
+	WebhookLogCleanRules []WebhookLogCleanRule `yaml:"webhookLogCleanRules"`
+	EventCleanRules      []EventCleanRule      `yaml:"eventCleanRules"`
+}

--- a/pkg/config/k8sevent/k8sevent.go
+++ b/pkg/config/k8sevent/k8sevent.go
@@ -1,0 +1,19 @@
+package k8sevent
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type Reason struct {
+	Reason   string   `yaml:"reason"`
+	Messages []string `yaml:"messages"`
+}
+
+type Rule struct {
+	schema.GroupVersionKind `yaml:",inline"`
+	Reasons                 []Reason `yaml:"reasons"`
+}
+
+type Config struct {
+	Rules []Rule `yaml:"rules"`
+}

--- a/pkg/event/dao/dao.go
+++ b/pkg/event/dao/dao.go
@@ -36,8 +36,6 @@ type DAO interface {
 		eventIndex *models.EventCursor) (*models.EventCursor, error)
 	GetCursor(ctx context.Context, cursorType models.EventCursorType,
 		regionIDs ...uint) (*models.EventCursor, error)
-	GetCursors(ctx context.Context, cursorType models.EventCursorType,
-		regionIDs ...uint) ([]*models.EventCursor, error)
 	GetEvent(ctx context.Context, id uint) (*models.Event, error)
 	DeleteEvents(ctx context.Context, id ...uint) (int64, error)
 }
@@ -132,23 +130,6 @@ func (d *dao) GetCursor(ctx context.Context,
 		return nil, herrors.NewErrGetFailed(herrors.EventCursorInDB, result.Error.Error())
 	}
 	return &eventIndex, nil
-}
-
-func (d *dao) GetCursors(ctx context.Context, cursorType models.EventCursorType,
-	regionIDs ...uint) ([]*models.EventCursor, error) {
-	var eventIndex []*models.EventCursor
-	statement := d.db.WithContext(ctx).Where("type = ?", cursorType)
-	if len(regionIDs) > 0 {
-		statement.Where("region_id in (?)", regionIDs)
-	}
-	if result := statement.Find(&eventIndex); result.Error != nil {
-		if result.Error == gorm.ErrRecordNotFound {
-			return nil, herrors.NewErrNotFound(herrors.EventCursorInDB,
-				result.Error.Error())
-		}
-		return nil, herrors.NewErrGetFailed(herrors.EventCursorInDB, result.Error.Error())
-	}
-	return eventIndex, nil
 }
 
 func (d *dao) DeleteEvents(ctx context.Context, ids ...uint) (int64, error) {

--- a/pkg/event/dao/dao.go
+++ b/pkg/event/dao/dao.go
@@ -151,17 +151,17 @@ func (d *dao) GetCursors(ctx context.Context, cursorType models.EventCursorType,
 	return eventIndex, nil
 }
 
-func (d *dao) DeleteEvents(ctx context.Context, id ...uint) (int64, error) {
+func (d *dao) DeleteEvents(ctx context.Context, ids ...uint) (int64, error) {
 	var events []*models.Event
 	tx := d.db.WithContext(ctx).Begin()
 
-	result := tx.Where("id in (?)", id).Delete(&events)
+	result := tx.Where("id in (?)", ids).Delete(&events)
 	if result.Error != nil {
 		tx.Rollback()
 		return 0, herrors.NewErrDeleteFailed(herrors.EventInDB, result.Error.Error())
 	}
 
-	if result := tx.Where("event_id in (?)", id).Delete(&webhookmodels.WebhookLog{}); result.Error != nil {
+	if result := tx.Where("event_id in (?)", ids).Delete(&webhookmodels.WebhookLog{}); result.Error != nil {
 		tx.Rollback()
 		return 0, herrors.NewErrDeleteFailed(herrors.WebhookLogInDB, result.Error.Error())
 	}

--- a/pkg/event/manager/manager.go
+++ b/pkg/event/manager/manager.go
@@ -38,8 +38,6 @@ type Manager interface {
 		eventIndex *models.EventCursor) (*models.EventCursor, error)
 	GetCursor(ctx context.Context, cursorType models.EventCursorType,
 		RegionIDs ...uint) (*models.EventCursor, error)
-	GetCursors(ctx context.Context, cursorType models.EventCursorType,
-		RegionIDs ...uint) ([]*models.EventCursor, error)
 	GetEvent(ctx context.Context, id uint) (*models.Event, error)
 	ListSupportEvents() map[string]string
 	DeleteEvents(ctx context.Context, id ...uint) (int64, error)
@@ -94,13 +92,6 @@ func (m *manager) GetCursor(ctx context.Context, cursorType models.EventCursorTy
 	const op = "event manager: get cursor"
 	defer wlog.Start(ctx, op).StopPrint()
 	return m.dao.GetCursor(ctx, cursorType, regionIDs...)
-}
-
-func (m *manager) GetCursors(ctx context.Context, cursorType models.EventCursorType,
-	regionIDs ...uint) ([]*models.EventCursor, error) {
-	const op = "event manager: get cursors"
-	defer wlog.Start(ctx, op).StopPrint()
-	return m.dao.GetCursors(ctx, cursorType, regionIDs...)
 }
 
 func (m *manager) ListEvents(ctx context.Context, query *q.Query) ([]*models.Event, error) {

--- a/pkg/event/manager/manager_test.go
+++ b/pkg/event/manager/manager_test.go
@@ -20,8 +20,10 @@ import (
 
 	"github.com/horizoncd/horizon/core/common"
 	"github.com/horizoncd/horizon/lib/orm"
+	"github.com/horizoncd/horizon/lib/q"
 	userauth "github.com/horizoncd/horizon/pkg/authentication/user"
 	eventmodels "github.com/horizoncd/horizon/pkg/event/models"
+	webhookmodels "github.com/horizoncd/horizon/pkg/webhook/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +35,7 @@ var (
 func createCtx() {
 	db, _ := orm.NewSqliteDB("file::memory:?cache=shared")
 	if err := db.AutoMigrate(&eventmodels.Event{},
-		&eventmodels.EventCursor{}); err != nil {
+		&eventmodels.EventCursor{}, &webhookmodels.WebhookLog{}); err != nil {
 		panic(err)
 	}
 	if err := db.AutoMigrate(); err != nil {
@@ -57,13 +59,37 @@ func Test(t *testing.T) {
 			ResourceID:   1,
 			EventType:    eventmodels.ClusterCreated,
 		},
+		ReqID: "xxx",
 	}
-	e, err := m.CreateEvent(ctx, e)
+	events, err := m.CreateEvent(ctx, e)
 	assert.Nil(t, err)
+	assert.Equal(t, 1, len(events))
 
+	e = events[0]
 	e2, err := m.GetEvent(ctx, e.ID)
 	assert.Nil(t, err)
 	assert.Equal(t, e.ResourceID, e2.ResourceID)
+
+	events, err = m.ListEvents(ctx, &q.Query{Keywords: q.KeyWords{common.ReqID: "xxx"}})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(events))
+
+	e.ID = 3
+	events, err = m.CreateEvent(ctx, e)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(events))
+
+	events, err = m.ListEvents(ctx, &q.Query{Keywords: q.KeyWords{common.ReqID: "xxx"}})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(events))
+
+	events, err = m.ListEvents(ctx, &q.Query{Keywords: q.KeyWords{common.StartID: 2, common.Limit: 10}})
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(events))
+
+	events, err = m.ListEvents(ctx, &q.Query{Keywords: q.KeyWords{common.StartID: 0, common.Limit: 10}})
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(events))
 
 	ec, err := m.CreateOrUpdateCursor(ctx, &eventmodels.EventCursor{
 		Position: 1,
@@ -74,7 +100,35 @@ func Test(t *testing.T) {
 	_, err = m.CreateOrUpdateCursor(ctx, ec)
 	assert.Nil(t, err)
 
-	ec2, err := m.GetCursor(ctx)
+	ec2, err := m.GetCursor(ctx, eventmodels.CursorHorizon)
 	assert.Nil(t, err)
 	assert.Equal(t, ec2.Position, ec2.Position)
+
+	ec1, err := m.CreateOrUpdateCursor(ctx, &eventmodels.EventCursor{
+		Position: 32,
+		Type:     eventmodels.CursorRegion,
+		RegionID: 1,
+	})
+	assert.Nil(t, err)
+
+	ec2, err = m.CreateOrUpdateCursor(ctx, &eventmodels.EventCursor{
+		Position: 2,
+		Type:     eventmodels.CursorRegion,
+		RegionID: 2,
+	})
+	assert.Nil(t, err)
+
+	ecs, err := m.GetCursors(ctx, eventmodels.CursorRegion)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 2, len(ecs))
+	assert.Equal(t, ec1.ID, uint(2))
+	assert.Equal(t, ec2.ID, uint(3))
+
+	_, err = m.DeleteEvents(ctx, 1, 3)
+	assert.Nil(t, err)
+
+	events, err = m.ListEvents(ctx, &q.Query{Keywords: q.KeyWords{common.StartID: 0, common.Limit: 10}})
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(events))
 }

--- a/pkg/event/manager/manager_test.go
+++ b/pkg/event/manager/manager_test.go
@@ -104,26 +104,19 @@ func Test(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, ec2.Position, ec2.Position)
 
-	ec1, err := m.CreateOrUpdateCursor(ctx, &eventmodels.EventCursor{
+	_, err = m.CreateOrUpdateCursor(ctx, &eventmodels.EventCursor{
 		Position: 32,
 		Type:     eventmodels.CursorRegion,
 		RegionID: 1,
 	})
 	assert.Nil(t, err)
 
-	ec2, err = m.CreateOrUpdateCursor(ctx, &eventmodels.EventCursor{
+	_, err = m.CreateOrUpdateCursor(ctx, &eventmodels.EventCursor{
 		Position: 2,
 		Type:     eventmodels.CursorRegion,
 		RegionID: 2,
 	})
 	assert.Nil(t, err)
-
-	ecs, err := m.GetCursors(ctx, eventmodels.CursorRegion)
-	assert.Nil(t, err)
-
-	assert.Equal(t, 2, len(ecs))
-	assert.Equal(t, ec1.ID, uint(2))
-	assert.Equal(t, ec2.ID, uint(3))
 
 	_, err = m.DeleteEvents(ctx, 1, 3)
 	assert.Nil(t, err)

--- a/pkg/event/models/event.go
+++ b/pkg/event/models/event.go
@@ -36,6 +36,8 @@ const (
 	ClusterPodsRescheduled string = "clusters_rescheduled"
 	ClusterUpdated         string = "clusters_updated"
 	ClusterFreed           string = "clusters_freed"
+	ClusterKubernetesEvent string = "clusters_kubernetes_event"
+	ClusterAction                 = "clusters_action"
 	// TODO: add group events
 )
 
@@ -54,9 +56,20 @@ type Event struct {
 	CreatedBy uint
 }
 
+type EventCursorType string
+
+const (
+	// CursorHorizon is the cursor for taking out events from db
+	CursorHorizon EventCursorType = "horizon"
+	// CursorRegion is the cursor for recording the resourceVersion of the last written event from kubernetes
+	CursorRegion EventCursorType = "region"
+)
+
 type EventCursor struct {
 	ID        uint
 	Position  uint
+	Type      EventCursorType `gorm:"default:'horizon';uniqueIndex:idx_type_region_id"`
+	RegionID  uint            `gorm:"column:region_id;uniqueIndex:idx_type_region_id"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/pkg/eventhandler/wlgenerator/wlgenerator.go
+++ b/pkg/eventhandler/wlgenerator/wlgenerator.go
@@ -188,17 +188,19 @@ func (w *WebhookLogGenerator) makeRequestHeaders(secret string) (string, error) 
 
 // makeRequestHeaders assemble body of webhook request
 func (w *WebhookLogGenerator) makeRequestBody(ctx context.Context, dep *messageDependency) (string, error) {
-	user, err := w.userMgr.GetUserByID(ctx, dep.event.CreatedBy)
-	if err != nil {
-		return "", err
-	}
-
 	message := MessageContent{
 		EventID:   dep.event.ID,
 		WebhookID: dep.webhook.ID,
-		EventType: string(dep.event.EventType),
-		User:      usermodels.ToUser(user),
+		EventType: dep.event.EventType,
 		Extra:     dep.event.EventSummary.Extra,
+	}
+
+	if dep.event.CreatedBy != 0 {
+		user, err := w.userMgr.GetUserByID(ctx, dep.event.CreatedBy)
+		if err != nil {
+			return "", err
+		}
+		message.User = usermodels.ToUser(user)
 	}
 
 	if dep.event.ResourceType == common.ResourceApplication &&

--- a/pkg/jobs/autofree/autofree.go
+++ b/pkg/jobs/autofree/autofree.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package jobautofree
+package autofree
 
 import (
 	"context"

--- a/pkg/jobs/autofree/autofree_test.go
+++ b/pkg/jobs/autofree/autofree_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package jobautofree
+package autofree
 
 import (
 	"context"

--- a/pkg/jobs/clean/cleaner.go
+++ b/pkg/jobs/clean/cleaner.go
@@ -1,0 +1,190 @@
+package clean
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/horizoncd/horizon/core/common"
+	"github.com/horizoncd/horizon/lib/q"
+	"github.com/horizoncd/horizon/pkg/config/clean"
+	"github.com/horizoncd/horizon/pkg/param/managerparam"
+	"github.com/horizoncd/horizon/pkg/util/log"
+	"github.com/robfig/cron/v3"
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+type Cleaner struct {
+	clean.Config
+	mgr              *managerparam.Manager
+	eventCursor      uint
+	webhookLogCursor uint
+}
+
+func New(config clean.Config, mgr *managerparam.Manager) *Cleaner {
+	if config.Batch == 0 {
+		config.Batch = 160
+	}
+	return &Cleaner{
+		Config: config,
+		mgr:    mgr,
+	}
+}
+
+func (c *Cleaner) Run(ctx context.Context) {
+	loc, err := time.LoadLocation("Asia/Shanghai")
+	if err != nil {
+		panic(err)
+	}
+	cron := cron.New(cron.WithSeconds(), cron.WithLocation(loc))
+	_, err = cron.AddFunc(c.TimeToRun, func() {
+		runtime.HandleCrash()
+		log.Debugf(ctx, "start to clean")
+		c.eventClean(ctx)
+		c.webhookLogClean(ctx)
+	})
+	if err != nil {
+		panic(err)
+	}
+	cron.Run()
+}
+
+func (c *Cleaner) webhookLogClean(ctx context.Context) {
+	log.Debugf(ctx, "start to clean webhooklogs")
+	defer func() {
+		c.webhookLogCursor = 0
+		log.Debugf(ctx, "finish to clean webhooklogs")
+	}()
+	if len(c.WebhookLogCleanRules) == 0 {
+		return
+	}
+	needDeleted := make([]uint, 0)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		query := &q.Query{
+			Keywords: q.KeyWords{
+				common.StartID: c.webhookLogCursor,
+				common.Limit:   c.Batch,
+				common.OrderBy: "l.id",
+			},
+		}
+		webhooklogs, _, err := c.mgr.WebhookManager.ListWebhookLogs(ctx, query, nil)
+		if err != nil {
+			log.Errorf(ctx, "failed to list webhooklogs: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		if len(webhooklogs) == 0 {
+			return
+		}
+
+		maxID := uint(0)
+		needDeleted = needDeleted[:0]
+		for _, webhooklog := range webhooklogs {
+			if webhooklog.ID > maxID {
+				maxID = webhooklog.ID
+			}
+			for _, rule := range c.WebhookLogCleanRules {
+				if webhooklog.UpdatedAt.Add(rule.TTL).Before(time.Now()) {
+					needDeleted = append(needDeleted, webhooklog.ID)
+				}
+			}
+		}
+
+		c.webhookLogCursor = maxID
+		if len(needDeleted) == 0 {
+			continue
+		}
+
+		log.Debugf(ctx, "need to delete webhooklogs: %v", needDeleted)
+		_, _ = c.mgr.WebhookManager.DeleteWebhookLogs(ctx, needDeleted...)
+	}
+}
+
+func (c *Cleaner) eventClean(ctx context.Context) {
+	log.Debugf(ctx, "start to clean events")
+	defer func() {
+		c.eventCursor = 0
+		log.Debugf(ctx, "finish to clean events")
+	}()
+	if len(c.EventCleanRules) == 0 {
+		return
+	}
+	needDeleted := make([]uint, 0)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		events, err := c.mgr.EventManager.ListEvents(ctx, &q.Query{Keywords: q.KeyWords{
+			common.Limit:   c.Batch,
+			common.StartID: int(c.eventCursor),
+		}})
+		if err != nil {
+			log.Errorf(ctx, "failed to list events: %v", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		if len(events) == 0 {
+			return
+		}
+
+		maxID := uint(0)
+		needDeleted = needDeleted[:0]
+	OUTTER:
+		for _, event := range events {
+			if event.ID > maxID {
+				maxID = event.ID
+			}
+			for _, rule := range c.EventCleanRules {
+				if rule.EventType != event.EventType {
+					continue
+				}
+				if time.Now().Before(event.CreatedAt.Add(rule.TTL)) {
+					continue
+				}
+				m := make(map[string]interface{})
+				if event.Extra != nil {
+					err = json.Unmarshal([]byte(*event.Extra), &m)
+					if err != nil {
+						log.Errorf(ctx, "failed to unmarshal event extra: %v", err)
+						continue
+					}
+					if rule.Reason != "" && rule.Reason != m["reason"] {
+						continue
+					}
+					involvedObject := m["involvedObject"].(map[string]interface{})
+					if involvedObject != nil {
+						if rule.APIVersion != "" && rule.APIVersion != involvedObject["apiVersion"] {
+							continue
+						}
+						if rule.Kind != "" && rule.Kind != involvedObject["kind"] {
+							continue
+						}
+						if rule.Name != "" && rule.Name != involvedObject["name"] {
+							continue
+						}
+						if rule.Namespace != "" && rule.Namespace != involvedObject["namespace"] {
+							continue
+						}
+					}
+				}
+				needDeleted = append(needDeleted, event.ID)
+				continue OUTTER
+			}
+		}
+		c.eventCursor = maxID
+		if len(needDeleted) == 0 {
+			continue
+		}
+		log.Debugf(ctx, "need to delete event: %v", needDeleted)
+		_, _ = c.mgr.EventManager.DeleteEvents(ctx, needDeleted...)
+	}
+}

--- a/pkg/jobs/eventhandler/eventhandler.go
+++ b/pkg/jobs/eventhandler/eventhandler.go
@@ -1,0 +1,23 @@
+package eventhandler
+
+import (
+	"context"
+
+	eventhandlercfg "github.com/horizoncd/horizon/pkg/config/eventhandler"
+	eventhandlersvc "github.com/horizoncd/horizon/pkg/eventhandler"
+	"github.com/horizoncd/horizon/pkg/jobs"
+	"github.com/horizoncd/horizon/pkg/param/managerparam"
+)
+
+func New(ctx context.Context, eventHandlerConfig eventhandlercfg.Config,
+	mgrs *managerparam.Manager) (jobs.Job, eventhandlersvc.Service) {
+	// start event handler service to generate webhook log by events
+	eventHandlerService := eventhandlersvc.NewService(ctx, mgrs, eventHandlerConfig)
+
+	return func(ctx context.Context) {
+		eventHandlerService.Start()
+		<-ctx.Done()
+		// graceful exit
+		eventHandlerService.StopAndWait()
+	}, eventHandlerService
+}

--- a/pkg/jobs/grafanasync/grafanasync.go
+++ b/pkg/jobs/grafanasync/grafanasync.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package jobgrafanasync
+package grafanasync
 
 import (
 	"context"

--- a/pkg/jobs/k8sevent/k8sevent.go
+++ b/pkg/jobs/k8sevent/k8sevent.go
@@ -1,0 +1,408 @@
+package k8sevent
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/horizoncd/horizon/core/common"
+	"github.com/horizoncd/horizon/core/operater"
+	"github.com/horizoncd/horizon/lib/q"
+	"github.com/horizoncd/horizon/pkg/config/k8sevent"
+	eventmanager "github.com/horizoncd/horizon/pkg/event/manager"
+	eventmodels "github.com/horizoncd/horizon/pkg/event/models"
+	"github.com/horizoncd/horizon/pkg/param/managerparam"
+	"github.com/horizoncd/horizon/pkg/region/models"
+	"github.com/horizoncd/horizon/pkg/util/log"
+	"gorm.io/gorm"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	cacheMax                   = 160
+	savingInterval             = 10 * time.Second
+	kubernetesInstanceLabelKey = "app.kubernetes.io/instance"
+)
+
+var gvrEvent = schema.GroupVersionResource{
+	Resource: "events",
+	Version:  "v1",
+	Group:    "",
+}
+
+type SuperVisor struct {
+	filter    *gvkFilter
+	informers *operater.RegionInformers
+	mgr       *managerparam.Manager
+	db        *gorm.DB
+	cacheMax  int
+}
+
+func New(config k8sevent.Config, informers *operater.RegionInformers,
+	mgr *managerparam.Manager, db *gorm.DB) *SuperVisor {
+	v := &SuperVisor{
+		filter:    newGVKFilter(config),
+		informers: informers,
+		mgr:       mgr,
+		db:        db,
+		cacheMax:  cacheMax,
+	}
+
+	return v
+}
+
+func (v *SuperVisor) Run(ctx context.Context) {
+	v.informers.Register(operater.Resource{GVR: gvrEvent, MakeHandler: v.newEventHandler})
+
+	v.informers.WatchDB(ctx, 60*time.Second)
+}
+
+type EventWithTime struct {
+	*eventmodels.Event
+	LastTimestamp time.Time
+}
+
+func (v *SuperVisor) newEventHandler(regionID uint, stopCh <-chan struct{}) (cache.ResourceEventHandler, error) {
+	log.Debugf(context.Background(), "new event handler for region %d", regionID)
+	ctx := context.Background()
+	entity, err := v.mgr.RegionMgr.GetRegionByID(ctx, regionID)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &eventHandler{
+		SuperVisor: v,
+		regionID:   regionID,
+		region:     entity.Region,
+		eventCh:    make(chan *corev1.Event),
+		cacheMax:   v.cacheMax,
+		stopCh:     stopCh,
+	}
+
+	go func() {
+		eventCache := make([]*corev1.Event, 0, v.cacheMax)
+		ticker := time.NewTicker(savingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if len(eventCache) == 0 {
+					ticker.Reset(savingInterval)
+					continue
+				}
+			case event := <-h.eventCh:
+				eventCache = append(eventCache, event)
+				if len(eventCache) < h.cacheMax {
+					continue
+				}
+			}
+			err := h.save(eventCache)
+			if err != nil {
+				log.Errorf(ctx, "failed to save event: %v", err)
+			}
+			eventCache = eventCache[:0]
+			ticker.Reset(savingInterval)
+		}
+	}()
+
+	return h, nil
+}
+
+type eventHandler struct {
+	*SuperVisor
+	regionID uint
+	region   *models.Region
+	cacheMax int
+
+	stopCh <-chan struct{}
+
+	eventCh chan *corev1.Event
+}
+
+func (e *eventHandler) save(cache []*corev1.Event) error {
+	select {
+	case <-e.stopCh:
+		return nil
+	default:
+	}
+
+	ctx := context.Background()
+	eventsWithTime := make([]*EventWithTime, len(cache))
+
+	reqIDs := sync.Map{}
+
+	wg := sync.WaitGroup{}
+	for i, event := range cache {
+		wg.Add(1)
+		go func(index int, event *corev1.Event, dst []*EventWithTime) {
+			defer wg.Done()
+			horizonEvent, err := e.mapEvent(event)
+			if err != nil {
+				log.Errorf(ctx, "failed to map event: %v", err)
+				return
+			}
+
+			// skip same reqID
+			if _, ok := reqIDs.Load(horizonEvent.ReqID); ok {
+				return
+			}
+
+			reqIDs.Store(horizonEvent.ReqID, struct{}{})
+
+			sameEvents, _ := e.mgr.EventManager.ListEvents(ctx, &q.Query{Keywords: q.KeyWords{common.ReqID: horizonEvent.ReqID}})
+			// skip same event
+			for _, sameEvent := range sameEvents {
+				if sameEvent.Extra != nil && horizonEvent.Extra != nil &&
+					*sameEvent.Extra == *horizonEvent.Extra {
+					return
+				}
+			}
+			dst[index] = &EventWithTime{horizonEvent, event.LastTimestamp.Time}
+		}(i, event, eventsWithTime)
+	}
+	wg.Wait()
+
+	// skip nil in eventsWithTime
+	for i := len(eventsWithTime) - 1; i >= 0; i-- {
+		if eventsWithTime[i] == nil {
+			eventsWithTime = append(eventsWithTime[:i], eventsWithTime[i+1:]...)
+		}
+	}
+
+	if len(eventsWithTime) == 0 {
+		return nil
+	}
+
+	sort.Slice(eventsWithTime, func(i, j int) bool {
+		return eventsWithTime[i].LastTimestamp.Before(eventsWithTime[j].LastTimestamp)
+	})
+
+	tx := e.db.WithContext(ctx).Begin()
+	txEventManager := eventmanager.New(tx)
+
+	events := make([]*eventmodels.Event, 0, len(eventsWithTime))
+	for _, event := range eventsWithTime {
+		events = append(events, event.Event)
+	}
+
+	_, err := txEventManager.CreateEvent(ctx, events...)
+	if err != nil {
+		log.Errorf(ctx, "failed to save regionEvents: %v", err)
+		tx.Rollback()
+		return nil
+	}
+
+	err = tx.Commit().Error
+	if err != nil {
+		log.Errorf(ctx, "failed to commit: %v", err)
+		tx.Rollback()
+		return nil
+	}
+	return nil
+}
+
+func (*eventHandler) compactEvent(event *corev1.Event) map[string]interface{} {
+	m := make(map[string]interface{})
+
+	m["message"] = event.Message
+	m["reason"] = event.Reason
+	m["type"] = event.Type
+	m["lastTimestamp"] = event.LastTimestamp
+	m["name"] = event.Name
+
+	obj := make(map[string]interface{})
+	obj["kind"] = event.InvolvedObject.Kind
+	obj["name"] = event.InvolvedObject.Name
+	obj["namespace"] = event.InvolvedObject.Namespace
+	obj["apiVersion"] = event.InvolvedObject.APIVersion
+	m["involvedObject"] = obj
+	return m
+}
+
+var GVKApplication = schema.GroupVersionKind{
+	Group:   "argoproj.io",
+	Version: "v1alpha1",
+	Kind:    "Application",
+}
+
+func (e *eventHandler) mapEvent(event *corev1.Event) (*eventmodels.Event, error) {
+	if event == nil {
+		return nil, nil
+	}
+	extra, err := json.Marshal(e.compactEvent(event))
+	if err != nil {
+		log.Errorf(context.Background(), "failed to marshal event: %v", err)
+		return nil, err
+	}
+	extraStr := string(extra)
+	horizonEvent := &eventmodels.Event{
+		EventSummary: eventmodels.EventSummary{
+			ResourceType: common.ResourceCluster,
+			EventType:    eventmodels.ClusterKubernetesEvent,
+			Extra:        &extraStr,
+		},
+		ReqID: string(event.UID),
+	}
+
+	involvedObj := event.InvolvedObject
+
+	var (
+		obj  runtime.Object
+		ns   = involvedObj.Namespace
+		name = involvedObj.Name
+		gvk  = involvedObj.GroupVersionKind()
+	)
+
+	if gvk == GVKApplication {
+		cluster, err := e.mgr.ClusterMgr.GetByName(context.Background(), name)
+		if err != nil {
+			return nil, err
+		}
+		horizonEvent.ResourceID = cluster.ID
+		return horizonEvent, nil
+	}
+
+	for {
+		gvr, err := e.informers.GVK2GVR(e.regionID, gvk)
+		if err != nil {
+			return nil, err
+		}
+		err = e.informers.GetDynamicInformer(e.regionID, gvr, func(informer informers.GenericInformer) error {
+			obj, err = informer.Lister().ByNamespace(ns).Get(name)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		un, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert object to unstructured")
+		}
+		labels := un.GetLabels()
+		if labels != nil && labels[kubernetesInstanceLabelKey] != "" {
+			instanceName := labels[kubernetesInstanceLabelKey]
+			cluster, err := e.mgr.ClusterMgr.GetByName(context.Background(), instanceName)
+			if err != nil {
+				return nil, err
+			}
+			horizonEvent.ResourceID = cluster.ID
+			return horizonEvent, nil
+		}
+		ownerReferences := un.GetOwnerReferences()
+		if len(ownerReferences) != 0 {
+			ownerReference := ownerReferences[0]
+			gvk = schema.FromAPIVersionAndKind(ownerReference.APIVersion, ownerReference.Kind)
+			name = ownerReference.Name
+		} else {
+			return horizonEvent, nil
+		}
+	}
+}
+
+func (e *eventHandler) addEventToCache(un *unstructured.Unstructured) {
+	event := &corev1.Event{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, event)
+	if err != nil {
+		log.Errorf(context.Background(), "failed to convert unstructured to event: %v", err)
+		return
+	}
+
+	if !e.filter.has(event) {
+		return
+	}
+
+	e.eventCh <- event
+}
+
+func (e *eventHandler) OnAdd(obj interface{}) {
+	log.Debugf(context.Background(), "%p: event added\n", e)
+	un, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		log.Errorf(context.Background(), "failed to convert object to unstructured")
+		return
+	}
+	e.addEventToCache(un)
+}
+
+func (e *eventHandler) OnUpdate(_, newObj interface{}) {
+	log.Debugf(context.Background(), "%v: event updated", e)
+	un, ok := newObj.(*unstructured.Unstructured)
+	if !ok {
+		log.Errorf(context.Background(), "failed to convert object to unstructured")
+		return
+	}
+	e.addEventToCache(un)
+}
+
+func (e *eventHandler) OnDelete(_ interface{}) {
+	// no need to handle delete event
+}
+
+type reasonIndex map[string][]*regexp.Regexp
+
+type gvkIndex map[schema.GroupVersionKind]reasonIndex
+
+type gvkFilter struct {
+	index gvkIndex
+}
+
+func newGVKFilter(config k8sevent.Config) *gvkFilter {
+	index := make(gvkIndex)
+
+	for _, rule := range config.Rules {
+		gvk := rule.GroupVersionKind
+		if _, ok := index[gvk]; !ok {
+			index[gvk] = make(reasonIndex)
+		}
+		for _, reason := range rule.Reasons {
+			if _, ok := index[gvk][reason.Reason]; !ok {
+				index[gvk][reason.Reason] = nil
+			}
+			for _, message := range reason.Messages {
+				if message == "" {
+					continue
+				}
+				pattern := regexp.MustCompile(message)
+				index[gvk][reason.Reason] = append(index[gvk][reason.Reason], pattern)
+			}
+		}
+	}
+
+	return &gvkFilter{index}
+}
+
+func (f *gvkFilter) has(event *corev1.Event) bool {
+	gvk := schema.FromAPIVersionAndKind(event.InvolvedObject.APIVersion, event.InvolvedObject.Kind)
+	if reasonIndex, ok := f.index[gvk]; ok {
+		if len(reasonIndex) == 0 {
+			return true
+		}
+		if patterns, ok := reasonIndex[event.Reason]; ok {
+			if len(patterns) == 0 {
+				return true
+			}
+			for _, pattern := range patterns {
+				if pattern.MatchString(event.Message) {
+					return true
+				}
+			}
+		}
+	}
+	log.Debugf(context.Background(),
+		"event (%s) has been skipped: gvk = %s, uid = %s", event.Message, gvk.String(), event.UID)
+	return false
+}

--- a/pkg/jobs/k8sevent/k8sevent.go
+++ b/pkg/jobs/k8sevent/k8sevent.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/horizoncd/horizon/core/common"
-	"github.com/horizoncd/horizon/core/operater"
 	"github.com/horizoncd/horizon/lib/q"
 	"github.com/horizoncd/horizon/pkg/config/k8sevent"
 	eventmanager "github.com/horizoncd/horizon/pkg/event/manager"
 	eventmodels "github.com/horizoncd/horizon/pkg/event/models"
 	"github.com/horizoncd/horizon/pkg/param/managerparam"
 	"github.com/horizoncd/horizon/pkg/region/models"
+	"github.com/horizoncd/horizon/pkg/regioninformers"
 	"github.com/horizoncd/horizon/pkg/util/log"
 	"gorm.io/gorm"
 	corev1 "k8s.io/api/core/v1"
@@ -41,13 +41,13 @@ var gvrEvent = schema.GroupVersionResource{
 
 type SuperVisor struct {
 	filter    *gvkFilter
-	informers *operater.RegionInformers
+	informers *regioninformers.RegionInformers
 	mgr       *managerparam.Manager
 	db        *gorm.DB
 	cacheMax  int
 }
 
-func New(config k8sevent.Config, informers *operater.RegionInformers,
+func New(config k8sevent.Config, informers *regioninformers.RegionInformers,
 	mgr *managerparam.Manager, db *gorm.DB) *SuperVisor {
 	v := &SuperVisor{
 		filter:    newGVKFilter(config),
@@ -61,7 +61,7 @@ func New(config k8sevent.Config, informers *operater.RegionInformers,
 }
 
 func (v *SuperVisor) Run(ctx context.Context) {
-	v.informers.Register(operater.Resource{GVR: gvrEvent, MakeHandler: v.newEventHandler})
+	v.informers.Register(regioninformers.Resource{GVR: gvrEvent, MakeHandler: v.newEventHandler})
 
 	v.informers.WatchDB(ctx, 60*time.Second)
 }

--- a/pkg/rbac/types/types_test.go
+++ b/pkg/rbac/types/types_test.go
@@ -115,7 +115,7 @@ func TestRuleAllow(t *testing.T) {
 			},
 			allowed: false,
 		}, {
-			// case list case deny (Resource)
+			// case list case deny (GVR)
 			attr: auth.AttributesRecord{
 				User:            &testUser,
 				Verb:            "delete",

--- a/pkg/regioninformers/regioninformers.go
+++ b/pkg/regioninformers/regioninformers.go
@@ -1,4 +1,4 @@
-package operater
+package regioninformers
 
 import (
 	"context"

--- a/pkg/regioninformers/regioninformers.go
+++ b/pkg/regioninformers/regioninformers.go
@@ -161,15 +161,6 @@ func (f *RegionInformers) listRegion(ctx context.Context) ([]*models.Region, err
 	if err != nil {
 		return nil, err
 	}
-	// offset := 0
-	// for i := range regions {
-	// 	if regions[i].Disabled {
-	// 		offset++
-	// 		continue
-	// 	}
-	// 	regions[i-offset] = regions[i]
-	// }
-	// return regions[:len(regions)-offset], nil
 	return regions, nil
 }
 

--- a/pkg/webhook/manager/manager.go
+++ b/pkg/webhook/manager/manager.go
@@ -35,7 +35,7 @@ type Manager interface {
 	DeleteWebhook(ctx context.Context, id uint) error
 	CreateWebhookLog(ctx context.Context, wl *models.WebhookLog) (*models.WebhookLog, error)
 	CreateWebhookLogs(ctx context.Context, wls []*models.WebhookLog) ([]*models.WebhookLog, error)
-	ListWebhookLogs(ctx context.Context, wID uint, query *q.Query,
+	ListWebhookLogs(ctx context.Context, query *q.Query,
 		resources map[string][]uint) ([]*models.WebhookLogWithEventInfo, int64, error)
 	ListWebhookLogsByMap(ctx context.Context,
 		webhookEventMap map[uint][]uint) ([]*models.WebhookLog, error)
@@ -46,6 +46,7 @@ type Manager interface {
 	ResendWebhook(ctx context.Context, id uint) (*models.WebhookLog, error)
 	GetWebhookLogByEventID(ctx context.Context, webhookID, eventID uint) (*models.WebhookLog, error)
 	GetMaxEventIDOfLog(ctx context.Context) (uint, error)
+	DeleteWebhookLogs(ctx context.Context, id ...uint) (int64, error)
 }
 
 type manager struct {
@@ -104,11 +105,11 @@ func (m *manager) CreateWebhookLog(ctx context.Context,
 	return m.dao.CreateWebhookLog(ctx, wl)
 }
 
-func (m *manager) ListWebhookLogs(ctx context.Context, wID uint,
-	query *q.Query, resources map[string][]uint) ([]*models.WebhookLogWithEventInfo, int64, error) {
+func (m *manager) ListWebhookLogs(ctx context.Context, query *q.Query,
+	resources map[string][]uint) ([]*models.WebhookLogWithEventInfo, int64, error) {
 	const op = "webhook manager: list webhook logs"
 	defer wlog.Start(ctx, op).StopPrint()
-	return m.dao.ListWebhookLogs(ctx, wID, query, resources)
+	return m.dao.ListWebhookLogs(ctx, query, resources)
 }
 
 func (m *manager) ListWebhookLogsByMap(ctx context.Context,
@@ -145,6 +146,13 @@ func (m *manager) GetWebhookLogByEventID(ctx context.Context, webhookID, eventID
 	const op = "webhook manager: get webhook log by event id"
 	defer wlog.Start(ctx, op).StopPrint()
 	return m.dao.GetWebhookLogByEventID(ctx, webhookID, eventID)
+}
+
+func (m *manager) DeleteWebhookLogs(ctx context.Context, id ...uint) (int64, error) {
+	const op = "webhook manager: delete webhook log"
+	defer wlog.Start(ctx, op).StopPrint()
+
+	return m.dao.DeleteWebhookLogs(ctx, id...)
 }
 
 func (m *manager) ResendWebhook(ctx context.Context, id uint) (*models.WebhookLog, error) {

--- a/pkg/workload/dummy/dummy.go
+++ b/pkg/workload/dummy/dummy.go
@@ -1,0 +1,35 @@
+package dummy
+
+import (
+	"github.com/horizoncd/horizon/pkg/workload"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func init() {
+	workload.Register(ability,
+		schema.GroupVersionResource{
+			Group:    "argoproj.io",
+			Version:  "v1alpha1",
+			Resource: "applications",
+		},
+		schema.GroupVersionResource{
+			Group:    "apps",
+			Version:  "v1",
+			Resource: "deployments",
+		})
+}
+
+var ability = &dummy{}
+
+// dummy is a dummy implementation of workload.Interface
+// It is used to register the ability to handle some required resources.
+type dummy struct{}
+
+func (*dummy) MatchGK(_ schema.GroupKind) bool {
+	return false
+}
+
+func (*dummy) Action(_ string, un *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	return un, nil
+}

--- a/pkg/workload/getter/getter.go
+++ b/pkg/workload/getter/getter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/horizoncd/horizon/pkg/util/kube"
 	"github.com/horizoncd/horizon/pkg/workload"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 )
 
 type Helper struct {
@@ -49,13 +50,14 @@ func (w *Helper) GetSteps(node *v1alpha1.ResourceNode, client *kube.Client) (*wo
 }
 
 // TODO: remove this after using informer
-func (w *Helper) ListPods(node *v1alpha1.ResourceNode, client *kube.Client) ([]corev1.Pod, error) {
+func (w *Helper) ListPods(node *v1alpha1.ResourceNode,
+	factory dynamicinformer.DynamicSharedInformerFactory) ([]corev1.Pod, error) {
 	lister, ok := w.inner.(workload.PodsLister)
 	if !ok {
 		return nil, perror.Wrapf(herrors.ErrMethodNotImplemented,
 			"workload %v not support list release", reflect.TypeOf(w.inner))
 	}
-	pods, err := lister.ListPods(node, client)
+	pods, err := lister.ListPods(node, factory)
 	if err != nil {
 		return nil,
 			herrors.NewErrGetFailed(herrors.ResourceInK8S,

--- a/pkg/workload/kservice/kservice.go
+++ b/pkg/workload/kservice/kservice.go
@@ -50,41 +50,6 @@ var (
 
 func init() {
 	workload.Register(ability, GVRService, GVRPod)
-	// schema.GroupVersionResource{
-	// 	Group:    "serving.knative.dev",
-	// 	Version:  "v1",
-	// 	Resource: "configurations",
-	// },
-	// schema.GroupVersionResource{
-	// 	Group:    "serving.knative.dev",
-	// 	Version:  "v1",
-	// 	Resource: "routes",
-	// },
-	// schema.GroupVersionResource{
-	// 	Group:    "serving.knative.dev",
-	// 	Version:  "v1",
-	// 	Resource: "revisions",
-	// },
-	// schema.GroupVersionResource{
-	// 	Group:    "networking.internal.knative.dev",
-	// 	Version:  "v1alpha1",
-	// 	Resource: "ingresses",
-	// },
-	// schema.GroupVersionResource{
-	// 	Group:    "",
-	// 	Version:  "v1",
-	// 	Resource: "pods",
-	// },
-	// schema.GroupVersionResource{
-	// 	Group:    "apps",
-	// 	Version:  "v1",
-	// 	Resource: "replicasets",
-	// },
-	// schema.GroupVersionResource{
-	// 	Group:    "apps",
-	// 	Version:  "v1",
-	// 	Resource: "deployments",
-	// },
 }
 
 // please refer to github.com/horizoncd/horizon/pkg/cluster/cd/workload/workload.go

--- a/pkg/workload/kservice/kservice.go
+++ b/pkg/workload/kservice/kservice.go
@@ -27,14 +27,64 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 	servicev1 "knative.dev/serving/pkg/apis/serving/v1"
 )
 
+var (
+	GVRService = schema.GroupVersionResource{
+		Group:    "serving.knative.dev",
+		Version:  "v1",
+		Resource: "services",
+	}
+	GVRPod = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
+)
+
 func init() {
-	workload.Register(ability)
+	workload.Register(ability, GVRService, GVRPod)
+	// schema.GroupVersionResource{
+	// 	Group:    "serving.knative.dev",
+	// 	Version:  "v1",
+	// 	Resource: "configurations",
+	// },
+	// schema.GroupVersionResource{
+	// 	Group:    "serving.knative.dev",
+	// 	Version:  "v1",
+	// 	Resource: "routes",
+	// },
+	// schema.GroupVersionResource{
+	// 	Group:    "serving.knative.dev",
+	// 	Version:  "v1",
+	// 	Resource: "revisions",
+	// },
+	// schema.GroupVersionResource{
+	// 	Group:    "networking.internal.knative.dev",
+	// 	Version:  "v1alpha1",
+	// 	Resource: "ingresses",
+	// },
+	// schema.GroupVersionResource{
+	// 	Group:    "",
+	// 	Version:  "v1",
+	// 	Resource: "pods",
+	// },
+	// schema.GroupVersionResource{
+	// 	Group:    "apps",
+	// 	Version:  "v1",
+	// 	Resource: "replicasets",
+	// },
+	// schema.GroupVersionResource{
+	// 	Group:    "apps",
+	// 	Version:  "v1",
+	// 	Resource: "deployments",
+	// },
 }
 
 // please refer to github.com/horizoncd/horizon/pkg/cluster/cd/workload/workload.go
@@ -44,6 +94,30 @@ type service struct{}
 
 func (*service) MatchGK(gk schema.GroupKind) bool {
 	return gk.Group == "serving.knative.dev" && gk.Kind == "Service"
+}
+
+func (*service) getService(node *v1alpha1.ResourceNode,
+	factory dynamicinformer.DynamicSharedInformerFactory) (*servicev1.Service, error) {
+	obj, err := factory.ForResource(GVRService).Lister().ByNamespace(node.Namespace).
+		Get(node.Name)
+	if err != nil {
+		return nil, perror.Wrapf(
+			herrors.NewErrGetFailed(herrors.ResourceInK8S,
+				"failed to get deployment in k8s"),
+			"failed to get deployment in k8s: deployment = %s, err = %v", node.Name, err)
+	}
+
+	un, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, perror.Wrapf(herrors.ErrParamInvalid, "failed to convert obj to unstructured")
+	}
+
+	var ksvc *servicev1.Service
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(un.UnstructuredContent(), &ksvc)
+	if err != nil {
+		return nil, err
+	}
+	return ksvc, nil
 }
 
 func (*service) getServiceByNode(node *v1alpha1.ResourceNode, client *kube.Client) (*servicev1.Service, error) {
@@ -70,20 +144,22 @@ func (*service) getServiceByNode(node *v1alpha1.ResourceNode, client *kube.Clien
 	return ksvc, nil
 }
 
-func (s *service) ListPods(node *v1alpha1.ResourceNode, client *kube.Client) ([]corev1.Pod, error) {
-	instance, err := s.getServiceByNode(node, client)
+func (s *service) ListPods(node *v1alpha1.ResourceNode,
+	factory dynamicinformer.DynamicSharedInformerFactory) ([]corev1.Pod, error) {
+	instance, err := s.getService(node, factory)
 	if err != nil {
 		return nil, err
 	}
 
-	selector := metav1.FormatLabelSelector(&metav1.LabelSelector{MatchLabels: instance.Spec.Template.Labels})
-	pods, err := client.Basic.CoreV1().Pods(instance.Namespace).
-		List(context.TODO(), metav1.ListOptions{LabelSelector: selector, ResourceVersion: "0"})
+	selector := labels.SelectorFromSet(instance.Spec.Template.ObjectMeta.Labels)
+	objs, err := factory.ForResource(GVRPod).Lister().ByNamespace(node.Namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
 
-	return pods.Items, nil
+	pods := workload.ObjIntoPod(objs...)
+
+	return pods, nil
 }
 
 func (s *service) IsHealthy(node *v1alpha1.ResourceNode,

--- a/pkg/workload/pod/pod.go
+++ b/pkg/workload/pod/pod.go
@@ -15,21 +15,26 @@
 package pod
 
 import (
-	"context"
-
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
 	herrors "github.com/horizoncd/horizon/core/errors"
 	perror "github.com/horizoncd/horizon/pkg/errors"
-	"github.com/horizoncd/horizon/pkg/util/kube"
 	"github.com/horizoncd/horizon/pkg/workload"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+)
+
+var (
+	GVRPod = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
 )
 
 func init() {
-	workload.Register(ability)
+	workload.Register(ability, GVRPod)
 }
 
 var ability = &pod{}
@@ -40,19 +45,21 @@ func (*pod) MatchGK(gk schema.GroupKind) bool {
 	return gk.Kind == "Pod"
 }
 
-func (*pod) getPodByNode(node *v1alpha1.ResourceNode, client *kube.Client) (*corev1.Pod, error) {
-	instance, err := client.Basic.CoreV1().Pods(node.Namespace).Get(context.TODO(), node.Name, metav1.GetOptions{})
+func (*pod) getPod(node *v1alpha1.ResourceNode,
+	factory dynamicinformer.DynamicSharedInformerFactory) (*corev1.Pod, error) {
+	instance, err := factory.ForResource(GVRPod).Lister().ByNamespace(node.Namespace).Get(node.Name)
 	if err != nil {
 		return nil, perror.Wrapf(
 			herrors.NewErrGetFailed(herrors.ResourceInK8S,
 				"failed to get deployment in k8s"),
 			"failed to get deployment in k8s: deployment = %s, err = %v", node.Name, err)
 	}
-	return instance, nil
+	return instance.(*corev1.Pod), nil
 }
 
-func (p *pod) ListPods(node *v1alpha1.ResourceNode, client *kube.Client) ([]corev1.Pod, error) {
-	instance, err := p.getPodByNode(node, client)
+func (p *pod) ListPods(node *v1alpha1.ResourceNode,
+	factory dynamicinformer.DynamicSharedInformerFactory) ([]corev1.Pod, error) {
+	instance, err := p.getPod(node, factory)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workload/rollout/rollout.go
+++ b/pkg/workload/rollout/rollout.go
@@ -16,6 +16,7 @@ package rollout
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 
@@ -257,6 +258,14 @@ func (r *rollout) GetSteps(node *v1alpha1.ResourceNode, client *kube.Client) (*w
 		return nil, err
 	}
 
+	bts, err := json.Marshal(map[string]interface{}{"currentIndex": *instance.Status.CurrentStepIndex})
+	if err != nil {
+		log.Errorf(context.TODO(), "marshal current step index failed: %v", err)
+		bts = append(bts, []byte("{}")...)
+	}
+
+	extra := string(bts)
+
 	// manual paused
 	return &workload.Step{
 		Index:        stepIndex,
@@ -264,6 +273,7 @@ func (r *rollout) GetSteps(node *v1alpha1.ResourceNode, client *kube.Client) (*w
 		Replicas:     incrementReplicasList,
 		ManualPaused: instance.Spec.Paused,
 		AutoPromote:  autoPromote,
+		Extra:        &extra,
 	}, nil
 }
 

--- a/pkg/workload/rollout/rollout.go
+++ b/pkg/workload/rollout/rollout.go
@@ -16,6 +16,7 @@ package rollout
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
@@ -28,13 +29,34 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/informers"
 	"k8s.io/kubectl/pkg/polymorphichelpers"
 )
 
+var (
+	GVRRollout = schema.GroupVersionResource{
+		Group:    "argoproj.io",
+		Version:  "v1alpha1",
+		Resource: "rollouts",
+	}
+	GVRReplicaSet = schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "replicasets",
+	}
+	GVRPod = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "pods",
+	}
+)
+
 func init() {
-	workload.Register(ability)
+	workload.Register(ability, GVRRollout, GVRReplicaSet, GVRPod)
 }
 
 // please refer to github.com/horizoncd/horizon/pkg/cluster/cd/workload/workload.go
@@ -44,6 +66,32 @@ type rollout struct{}
 
 func (*rollout) MatchGK(gk schema.GroupKind) bool {
 	return gk.Group == "argoproj.io" && gk.Kind == "Rollout"
+}
+
+func (*rollout) getRollout(node *v1alpha1.ResourceNode,
+	rolloutInformer informers.GenericInformer) (*rolloutsv1alpha1.Rollout, *unstructured.Unstructured, error) {
+	obj, err := rolloutInformer.Lister().ByNamespace(node.Namespace).Get(node.Name)
+	if err != nil {
+		return nil, nil, perror.Wrapf(
+			herrors.NewErrGetFailed(herrors.ResourceInK8S,
+				"failed to get rollout in k8s"),
+			"failed to get rollout in k8s: deployment = %s, err = %v", node.Name, err)
+	}
+
+	un, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, nil, perror.Wrapf(
+			herrors.NewErrGetFailed(herrors.ResourceInK8S,
+				"failed to get rollout in k8s"),
+			"failed to get rollout in k8s: deployment = %s, err = \"could not convert obj into unstructured\"", node.Name)
+	}
+
+	var instance *rolloutsv1alpha1.Rollout
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(un.UnstructuredContent(), &instance)
+	if err != nil {
+		return nil, un, err
+	}
+	return instance, un, nil
 }
 
 func (*rollout) getRolloutByNode(node *v1alpha1.ResourceNode,
@@ -131,19 +179,28 @@ OUTTER:
 	return true, nil
 }
 
-func (r *rollout) ListPods(node *v1alpha1.ResourceNode, client *kube.Client) ([]corev1.Pod, error) {
-	instance, _, err := r.getRolloutByNode(node, client)
+func (r *rollout) ListPods(node *v1alpha1.ResourceNode,
+	factory dynamicinformer.DynamicSharedInformerFactory) ([]corev1.Pod, error) {
+	rolloutInformer := factory.ForResource(GVRRollout)
+	podInformer := factory.ForResource(GVRPod)
+
+	instance, _, err := r.getRollout(node, rolloutInformer)
 	if err != nil {
 		return nil, err
 	}
 
-	labels := polymorphichelpers.MakeLabels(instance.Spec.Template.ObjectMeta.Labels)
-	pods, err := client.Basic.CoreV1().Pods(instance.Namespace).
-		List(context.TODO(), metav1.ListOptions{LabelSelector: labels, ResourceVersion: "0"})
+	selector := labels.SelectorFromSet(instance.Spec.Template.ObjectMeta.Labels)
+	if err != nil {
+		return nil, herrors.NewErrGetFailed(herrors.ResourceInK8S,
+			fmt.Sprintf("failed to get selectors for object %s/%s", instance.Namespace, instance.Name))
+	}
+	objs, err := podInformer.Lister().ByNamespace(node.Namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
-	return pods.Items, nil
+
+	pods := workload.ObjIntoPod(objs...)
+	return pods, nil
 }
 
 func (r *rollout) GetSteps(node *v1alpha1.ResourceNode, client *kube.Client) (*workload.Step, error) {

--- a/pkg/workload/type.go
+++ b/pkg/workload/type.go
@@ -24,6 +24,7 @@ type Step struct {
 	Replicas     []int
 	ManualPaused bool
 	AutoPromote  bool
+	Extra        *string
 }
 
 type Revision struct {

--- a/pkg/workload/util.go
+++ b/pkg/workload/util.go
@@ -1,0 +1,34 @@
+package workload
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/horizoncd/horizon/pkg/util/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func ObjIntoPod(objs ...runtime.Object) []corev1.Pod {
+	pods := make([]corev1.Pod, len(objs))
+	for i, obj := range objs {
+		pod := corev1.Pod{}
+		err := ObjUnmarshal(obj, &pod)
+		if err != nil {
+			log.Errorf(context.TODO(), "failed to unmarshal pod object: %v", err)
+			continue
+		}
+		pods[i] = pod
+	}
+	return pods
+}
+
+func ObjUnmarshal(obj runtime.Object, container interface{}) error {
+	un, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("obj is not *unstructured.Unstructured")
+	}
+
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(un.Object, container)
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -16,7 +16,7 @@ package workload
 
 import (
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
-	"github.com/horizoncd/horizon/core/operater"
+	"github.com/horizoncd/horizon/pkg/regioninformers"
 	"github.com/horizoncd/horizon/pkg/util/kube"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -26,13 +26,13 @@ import (
 
 var abilities = make([]Workload, 0, 4)
 
-var Resources = make([]operater.Resource, 0, 16)
+var Resources = make([]regioninformers.Resource, 0, 16)
 
 func Register(ability Workload, gvrs ...schema.GroupVersionResource) {
 	abilities = append(abilities, ability)
-	gvrsUnderResource := make([]operater.Resource, 0, len(gvrs))
+	gvrsUnderResource := make([]regioninformers.Resource, 0, len(gvrs))
 	for _, gvr := range gvrs {
-		gvrsUnderResource = append(gvrsUnderResource, operater.Resource{
+		gvrsUnderResource = append(gvrsUnderResource, regioninformers.Resource{
 			GVR: gvr,
 		})
 	}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open Horizon issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

1. Add k8s event package to listen for k8s events and write them to the database.
2. Use informer to list all pods in the resourcetree, greatly reducing the pressure on the kube API server.
3. Add a clean job to periodically clean up webhook logs and events.


Fixes https://github.com/horizoncd/horizon/issues/147

I have:

- [x] Read and followed Horizon's [contribution process](https://github.com/horizoncd/horizon/CONTRIBUTING.md).
- [x] Run `make build && make lint` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Has been tested on dev environment

### Special notes for your reviewer

@iamyeka @bysph 
<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
