### PR TITLE
fix: remove deleted cluster metrics

### DIFF
--- a/pkg/cluster/metrics/cluster.go
+++ b/pkg/cluster/metrics/cluster.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -75,19 +74,6 @@ func (c *Collector) getClusters() []*item {
 	// nolint
 	ctx = context.WithValue(ctx, common.UserContextKey(), &userauth.DefaultInfo{ID: 0})
 
-	_, deletedClusters, err := c.managers.ClusterMgr.List(ctx, &q.Query{
-		Keywords: q.KeyWords{
-			common.ClusterQueryUpdatedAfter: time.Now().Add(-15 * time.Minute),
-			common.ClusterQueryOnlyDeleted:  true,
-		},
-		Sorts:             []*q.Sort{{Key: "c.created_at", DESC: true}},
-		WithoutPagination: true,
-	})
-	if err != nil {
-		log.Errorf(ctx, "Failed to get deleted clusters: %v", err)
-		return []*item{}
-	}
-
 	_, clusters, err := c.managers.ClusterMgr.List(ctx, &q.Query{
 		Sorts:             []*q.Sort{{Key: "c.created_at", DESC: true}},
 		WithoutPagination: true,
@@ -96,8 +82,6 @@ func (c *Collector) getClusters() []*item {
 		log.Errorf(ctx, "Failed to get clusters: %v", err)
 		return []*item{}
 	}
-
-	clusters = append(clusters, deletedClusters...)
 
 	clusterIDs := make([]uint, 0)
 	m := make(map[uint]struct{})

--- a/pkg/cluster/metrics/cluster_test.go
+++ b/pkg/cluster/metrics/cluster_test.go
@@ -120,19 +120,4 @@ horizon_cluster_labels{application="app1",cluster="cluster2",label_hello_world1=
 `)
 	err = testutil.CollectAndCompare(collector, strReader)
 	assert.Nil(t, err)
-
-	err = mgr.ClusterMgr.DeleteByID(ctx, cluster2.ID)
-	assert.Nil(t, err)
-
-	strReader = strings.NewReader(`# HELP horizon_cluster_info A metric with a constant '1' value labeled by cluster, application, group, etc.
-# TYPE horizon_cluster_info gauge
-horizon_cluster_info{application="app1",cluster="cluster1",environment="dev",group="group1",region="hz",template="javaapp"} 1
-horizon_cluster_info{application="app1",cluster="cluster2",environment="dev",group="group1",region="hz",template="javaapp"} 1
-# HELP horizon_cluster_labels A metric with a constant '1' value labeled by cluster and tags
-# TYPE horizon_cluster_labels gauge
-horizon_cluster_labels{application="app1",cluster="cluster1",label_name="cluster1"} 1
-horizon_cluster_labels{application="app1",cluster="cluster2",label_hello_world1="cluster2",label_hello_world2="cluster2",label_name="cluster2"} 1
-`)
-	err = testutil.CollectAndCompare(collector, strReader)
-	assert.Nil(t, err)
 }


### PR DESCRIPTION
### Description of your changes

Deleted cluster in metrics is useless, for tags has hard deleted.

I have:

- [x] Read and followed Horizon's [contribution process](https://github.com/horizoncd/horizon/CONTRIBUTING.md).
- [x] Run `make build && make lint` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
