### PR TITLE
fix: list pods by resourceTree instread of labelSelectors

### DIFF
--- a/pkg/cd/cd.go
+++ b/pkg/cd/cd.go
@@ -202,37 +202,6 @@ func (c *cd) GetResourceTree(ctx context.Context,
 		return nil, err
 	}
 
-	podsMap := make(map[string]*corev1.Pod)
-	c.traverseResourceTree(resourceTreeInArgo, func(node *ResourceTreeNode) bool {
-		ifContinue := false
-		workload.LoopAbilities(func(workload workload.Workload) bool {
-			if !workload.MatchGK(schema.GroupKind{Group: node.Group, Kind: node.Kind}) {
-				return true
-			}
-			gt := getter.New(workload)
-
-			var (
-				pods []corev1.Pod
-				err  error
-			)
-			_ = c.informerFactories.GetDynamicFactory(params.RegionEntity.ID,
-				func(factory dynamicinformer.DynamicSharedInformerFactory) error {
-					pods, err = gt.ListPods(node.ResourceNode, factory)
-					return nil
-				})
-			if err != nil {
-				return true
-			}
-
-			for i := range pods {
-				podsMap[string(pods[i].UID)] = &pods[i]
-			}
-			ifContinue = false
-			return false
-		})
-		return ifContinue
-	})
-
 	resourceTree := make([]ResourceNode, 0, len(resourceTreeInArgo.Nodes))
 	pd, err := workload.GetAbility(GKPod)
 	if err != nil {

--- a/pkg/workload/pod/pod.go
+++ b/pkg/workload/pod/pod.go
@@ -47,14 +47,16 @@ func (*pod) MatchGK(gk schema.GroupKind) bool {
 
 func (*pod) getPod(node *v1alpha1.ResourceNode,
 	factory dynamicinformer.DynamicSharedInformerFactory) (*corev1.Pod, error) {
-	instance, err := factory.ForResource(GVRPod).Lister().ByNamespace(node.Namespace).Get(node.Name)
+	obj, err := factory.ForResource(GVRPod).Lister().ByNamespace(node.Namespace).Get(node.Name)
 	if err != nil {
 		return nil, perror.Wrapf(
 			herrors.NewErrGetFailed(herrors.ResourceInK8S,
 				"failed to get deployment in k8s"),
 			"failed to get deployment in k8s: deployment = %s, err = %v", node.Name, err)
 	}
-	return instance.(*corev1.Pod), nil
+	pods := workload.ObjIntoPod(obj)
+
+	return &pods[0], nil
 }
 
 func (p *pod) ListPods(node *v1alpha1.ResourceNode,

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -15,7 +15,10 @@
 package workload
 
 import (
+	"fmt"
+
 	"github.com/argoproj/argo-cd/pkg/apis/application/v1alpha1"
+	herrors "github.com/horizoncd/horizon/core/errors"
 	"github.com/horizoncd/horizon/pkg/regioninformers"
 	"github.com/horizoncd/horizon/pkg/util/kube"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +40,16 @@ func Register(ability Workload, gvrs ...schema.GroupVersionResource) {
 		})
 	}
 	Resources = append(Resources, gvrsUnderResource...)
+}
+
+func GetAbility(gk schema.GroupKind) (Workload, error) {
+	for _, ability := range abilities {
+		if ability.MatchGK(gk) {
+			return ability, nil
+		}
+	}
+	return nil, herrors.NewErrGetFailed(herrors.StepInWorkload,
+		fmt.Sprintf("ability does not exist, gk = %v", gk))
 }
 
 type Handler func(workload Workload) bool


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open Horizon issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
-->

Using tag selectors to query a list of pods is not entirely reliable, ArgoCD consider that and utilizes the owner reference to build a resource tree,  Horizon should rely on it too.

I have:

- [x] Read and followed Horizon's [contribution process](https://github.com/horizoncd/horizon/CONTRIBUTING.md).
- [x] Run `make build && make lint` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

I have tested this code in local and dev environment, pod list remains the same as before this fix.

### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
