### PR TITLE
feat: support region-argocd mapper

### DIFF
--- a/core/cmd/cmd.go
+++ b/core/cmd/cmd.go
@@ -471,7 +471,7 @@ func Init(ctx context.Context, flags *Flags, coreConfig *config.Config) {
 		ScopeService:         scopeService,
 		ApplicationGitRepo:   applicationGitRepo,
 		TemplateSchemaGetter: templateSchemaGetter,
-		CD: cd.NewCD(regionInformers, clusterGitRepo, coreConfig.ArgoCDMapper,
+		CD: cd.NewCD(regionInformers, clusterGitRepo, coreConfig.ArgoCDMapper, coreConfig.RegionArgoCDMapper,
 			coreConfig.GitopsRepoConfig.DefaultBranch),
 		K8sUtil:        cd.NewK8sUtil(regionInformers, manager.EventMgr),
 		OutputGetter:   outputGetter,

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	SessionConfig          session.Config          `yaml:"sessionConfig"`
 	GitopsRepoConfig       gitlab.GitopsRepoConfig `yaml:"gitopsRepoConfig"`
 	ArgoCDMapper           argocd.Mapper           `yaml:"argoCDMapper"`
+	RegionArgoCDMapper     argocd.RegionMapper     `yaml:"regionArgoCDMapper"`
 	RedisConfig            redis.Redis             `yaml:"redisConfig"`
 	TektonMapper           tekton.Mapper           `yaml:"tektonMapper"`
 	TemplateRepo           templaterepo.Repo       `yaml:"templateRepo"`
@@ -90,6 +91,15 @@ func LoadConfig(configFilePath string) (*Config, error) {
 		}
 	}
 	config.ArgoCDMapper = newArgoCDMapper
+
+	newRegionCDMapper := argocd.RegionMapper{}
+	for key, v := range config.RegionArgoCDMapper {
+		ks := strings.Split(key, ",")
+		for i := 0; i < len(ks); i++ {
+			newRegionCDMapper[ks[i]] = v
+		}
+	}
+	config.RegionArgoCDMapper = newRegionCDMapper
 
 	newTektonMapper := tekton.Mapper{}
 	for key, v := range config.TektonMapper {

--- a/core/controller/cluster/controller_basic.go
+++ b/core/controller/cluster/controller_basic.go
@@ -845,6 +845,7 @@ func (c *controller) DeleteCluster(ctx context.Context, clusterID uint, hard boo
 		if err = c.cd.DeleteCluster(newctx, &cd.DeleteClusterParams{
 			Environment: cluster.EnvironmentName,
 			Cluster:     cluster.Name,
+			Region:      cluster.RegionName,
 		}); err != nil {
 			log.Errorf(newctx, "failed to delete cluster: %v in cd system, err: %v", cluster.Name, err)
 			return
@@ -966,6 +967,7 @@ func (c *controller) FreeCluster(ctx context.Context, clusterID uint) (err error
 		if err = c.cd.DeleteCluster(newctx, &cd.DeleteClusterParams{
 			Environment: cluster.EnvironmentName,
 			Cluster:     cluster.Name,
+			Region:      cluster.RegionName,
 		}); err != nil {
 			log.Errorf(newctx, "failed to delete cluster: %v in cd system, err: %v", cluster.Name, err)
 			return

--- a/core/controller/cluster/controller_internal.go
+++ b/core/controller/cluster/controller_internal.go
@@ -142,6 +142,7 @@ func (c *controller) InternalDeploy(ctx context.Context, clusterID uint,
 		Environment: cluster.EnvironmentName,
 		Cluster:     cluster.Name,
 		Revision:    masterRevision,
+		Region:      cluster.RegionName,
 	}); err != nil {
 		return nil, err
 	}

--- a/core/controller/cluster/controller_internal_v2.go
+++ b/core/controller/cluster/controller_internal_v2.go
@@ -180,6 +180,7 @@ func (c *controller) InternalDeployV2(ctx context.Context, clusterID uint,
 		Environment: cluster.EnvironmentName,
 		Cluster:     cluster.Name,
 		Revision:    masterRevision,
+		Region:      cluster.RegionName,
 	}); err != nil {
 		return nil, err
 	}

--- a/core/controller/cluster/controller_operation.go
+++ b/core/controller/cluster/controller_operation.go
@@ -95,6 +95,7 @@ func (c *controller) Restart(ctx context.Context, clusterID uint) (_ *Pipelineru
 		Environment: cluster.EnvironmentName,
 		Cluster:     cluster.Name,
 		Revision:    commit,
+		Region:      cluster.RegionName,
 	}); err != nil {
 		return nil, err
 	}
@@ -412,6 +413,7 @@ func (c *controller) Rollback(ctx context.Context,
 		Environment: cluster.EnvironmentName,
 		Cluster:     cluster.Name,
 		Revision:    masterRevision,
+		Region:      cluster.RegionName,
 	}); err != nil {
 		return nil, err
 	}

--- a/core/controller/pipelinerun/controller.go
+++ b/core/controller/pipelinerun/controller.go
@@ -558,6 +558,7 @@ func (c *controller) executeRestart(ctx context.Context, application *appmodels.
 		Environment: cluster.EnvironmentName,
 		Cluster:     cluster.Name,
 		Revision:    commit,
+		Region:      cluster.RegionName,
 	}); err != nil {
 		return perror.Wrapf(err, "failed to deploy cluster in CD, cluster = %s, revision = %s",
 			cluster.Name, commit)
@@ -668,6 +669,7 @@ func (c *controller) executeRollback(ctx context.Context, application *appmodels
 		Environment: cluster.EnvironmentName,
 		Cluster:     cluster.Name,
 		Revision:    masterRevision,
+		Region:      cluster.RegionName,
 	}); err != nil {
 		return perror.Wrapf(err, "failed to deploy cluster in CD, cluster = %s, revision = %s",
 			cluster.Name, masterRevision)

--- a/pkg/argocd/facotry.go
+++ b/pkg/argocd/facotry.go
@@ -24,31 +24,40 @@ import (
 const _default = "default"
 
 type Factory interface {
-	GetArgoCD(environment string) (ArgoCD, error)
+	GetArgoCD(region string, environment string) (ArgoCD, error)
 }
 
 type factory struct {
-	cache *sync.Map
+	cache       *sync.Map
+	regionCache *sync.Map
 }
 
-func NewFactory(argoCDMapper argocd.Mapper) Factory {
+func NewFactory(argoCDMapper argocd.Mapper, regionArgoCDMapper argocd.RegionMapper) Factory {
 	cache := &sync.Map{}
 	for env, argoCDConf := range argoCDMapper {
 		argoCD := NewArgoCD(argoCDConf.URL, argoCDConf.Token, argoCDConf.Namespace)
 		cache.Store(env, argoCD)
 	}
+	regionCache := &sync.Map{}
+	for region, argoCDConf := range regionArgoCDMapper {
+		argoCD := NewArgoCD(argoCDConf.URL, argoCDConf.Token, argoCDConf.Namespace)
+		regionCache.Store(region, argoCD)
+	}
 	return &factory{
-		cache: cache,
+		cache:       cache,
+		regionCache: regionCache,
 	}
 }
 
-func (f *factory) GetArgoCD(environment string) (ArgoCD, error) {
+func (f *factory) GetArgoCD(region string, environment string) (ArgoCD, error) {
 	var ret interface{}
 	var ok bool
-	if ret, ok = f.cache.Load(environment); !ok {
-		// check and use default cd
-		if ret, ok = f.cache.Load(_default); !ok {
-			return nil, herrors.NewErrNotFound(herrors.ArgoCD, "default argo cd not found")
+	if ret, ok = f.regionCache.Load(region); !ok {
+		if ret, ok = f.cache.Load(environment); !ok {
+			// check and use default cd
+			if ret, ok = f.cache.Load(_default); !ok {
+				return nil, herrors.NewErrNotFound(herrors.ArgoCD, "default argo cd not found")
+			}
 		}
 	}
 	return ret.(ArgoCD), nil

--- a/pkg/cd/cd.go
+++ b/pkg/cd/cd.go
@@ -105,11 +105,11 @@ type cd struct {
 }
 
 func NewCD(informerFactories *regioninformers.RegionInformers, clusterGitRepo gitrepo.ClusterGitRepo,
-	argoCDMapper argocdconf.Mapper, targetRevision string) CD {
+	argoCDMapper argocdconf.Mapper, regionArgoCDMapper argocdconf.RegionMapper, targetRevision string) CD {
 	return &cd{
 		kubeClientFactory: kubeclient.Fty,
 		informerFactories: informerFactories,
-		factory:           argocd.NewFactory(argoCDMapper),
+		factory:           argocd.NewFactory(argoCDMapper, regionArgoCDMapper),
 		clusterGitRepo:    clusterGitRepo,
 		targetRevision:    targetRevision,
 	}
@@ -119,7 +119,7 @@ func (c *cd) CreateCluster(ctx context.Context, params *CreateClusterParams) (er
 	const op = "cd: create cluster"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	argo, err := c.factory.GetArgoCD(params.Environment)
+	argo, err := c.factory.GetArgoCD(params.RegionEntity.Name, params.Environment)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func (c *cd) DeployCluster(ctx context.Context, params *DeployClusterParams) (er
 	const op = "cd: deploy cluster"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	argo, err := c.factory.GetArgoCD(params.Environment)
+	argo, err := c.factory.GetArgoCD(params.Region, params.Environment)
 	if err != nil {
 		return perror.Wrap(herrors.ErrParamInvalid, err.Error())
 	}
@@ -163,7 +163,7 @@ func (c *cd) DeleteCluster(ctx context.Context, params *DeleteClusterParams) (er
 	const op = "cd: delete cluster"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	argo, err := c.factory.GetArgoCD(params.Environment)
+	argo, err := c.factory.GetArgoCD(params.Region, params.Environment)
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func (c *cd) GetResourceTree(ctx context.Context,
 	const op = "cd: get resource tree"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	argo, err := c.factory.GetArgoCD(params.Environment)
+	argo, err := c.factory.GetArgoCD(params.RegionEntity.Name, params.Environment)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (c *cd) GetStep(ctx context.Context, params *GetStepParams) (*Step, error) 
 		return nil, err
 	}
 
-	argo, err := c.factory.GetArgoCD(params.Environment)
+	argo, err := c.factory.GetArgoCD(params.RegionEntity.Name, params.Environment)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (c *cd) GetClusterState(ctx context.Context,
 	const op = "cd: get cluster status"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	argo, err := c.factory.GetArgoCD(params.Environment)
+	argo, err := c.factory.GetArgoCD(params.RegionEntity.Name, params.Environment)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +396,7 @@ func (c *cd) GetClusterStateV1(ctx context.Context,
 	const op = "cd: get cluster status"
 	defer wlog.Start(ctx, op).StopPrint()
 
-	argo, err := c.factory.GetArgoCD(params.Environment)
+	argo, err := c.factory.GetArgoCD(params.RegionEntity.Name, params.Environment)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cd/types.go
+++ b/pkg/cd/types.go
@@ -62,6 +62,7 @@ type DeployClusterParams struct {
 	Environment string
 	Cluster     string
 	Revision    string
+	Region      string
 }
 
 type GetPodEventsParams struct {
@@ -88,6 +89,7 @@ type DeletePodsParams struct {
 type DeleteClusterParams struct {
 	Environment string
 	Cluster     string
+	Region      string
 }
 
 type ExecuteActionParams struct {

--- a/pkg/config/argocd/argocd.go
+++ b/pkg/config/argocd/argocd.go
@@ -14,6 +14,9 @@
 
 package argocd
 
+// RegionMapper represents a region-to-ArgoCD Mapper configurations.
+type RegionMapper map[string]*ArgoCD
+
 type Mapper map[string]*ArgoCD
 
 type ArgoCD struct {


### PR DESCRIPTION
### Description of your changes

Support region-argocd mapper which has priority over the existing env-argocd mapper, like the config below:
```
regionArgoCDMapper:
  region,region2:
    url: 
    token: 
```

I have:

- [x] Read and followed Horizon's [contribution process](https://github.com/horizoncd/horizon/CONTRIBUTING.md).
- [x] Run `make build && make lint` to ensure this PR is ready for review.

### How has this code been tested
Run the test file `pkg/argocd/facotry_test.go`



