### PR TITLE
fix: do nothing when validating webhooks is empty

### DIFF
--- a/pkg/admission/webhook.go
+++ b/pkg/admission/webhook.go
@@ -51,6 +51,9 @@ type Webhook interface {
 }
 
 func Validating(ctx context.Context, request *Request) error {
+	if len(validatingWebhooks) < 1 {
+		return nil
+	}
 	ctx, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
 	finishedCount := 0


### PR DESCRIPTION
### Description of your changes

Wait do validatingWebhooks will block when validatingWebhooks is empty, we should skip it.





