### PR TITLE
feat: add tekton log bucket prefix support

### DIFF
--- a/lib/s3/s3_test.go
+++ b/lib/s3/s3_test.go
@@ -44,6 +44,7 @@ func Test(t *testing.T) {
 		ContentType:      "text/plain",
 		SkipVerify:       true,
 		S3ForcePathStyle: true,
+		Prefix:           "test",
 		// LogLevel:         func() *aws.LogLevelType { l := aws.LogDebugWithHTTPBody; return &l }(),
 	}
 

--- a/pkg/cluster/tekton/factory/factory.go
+++ b/pkg/cluster/tekton/factory/factory.go
@@ -61,6 +61,7 @@ func NewFactory(tektonMapper tektonconfig.Mapper) (Factory, error) {
 				Region:           tektonConfig.LogStorage.Region,
 				Endpoint:         tektonConfig.LogStorage.Endpoint,
 				Bucket:           tektonConfig.LogStorage.Bucket,
+				Prefix:           tektonConfig.LogStorage.Prefix,
 				DisableSSL:       tektonConfig.LogStorage.DisableSSL,
 				SkipVerify:       tektonConfig.LogStorage.SkipVerify,
 				S3ForcePathStyle: tektonConfig.LogStorage.S3ForcePathStyle,

--- a/pkg/config/tekton/tekton.go
+++ b/pkg/config/tekton/tekton.go
@@ -30,6 +30,7 @@ type LogStorage struct {
 	Region           string `yaml:"region"`
 	Endpoint         string `yaml:"endpoint"`
 	Bucket           string `yaml:"bucket"`
+	Prefix           string `yaml:"prefix"`
 	DisableSSL       bool   `yaml:"disableSSL"`
 	SkipVerify       bool   `yaml:"skipVerify"`
 	S3ForcePathStyle bool   `yaml:"s3ForcePathStyle"`


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open Horizon issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Configure prefix to store tekton logs in S3.

I have:

- [x] Read and followed Horizon's [contribution process](https://github.com/horizoncd/horizon/CONTRIBUTING.md).
- [x] Run `make build && make lint` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
