### PR TITLE
fix: update webhook cleaner sql

### DIFF
--- a/pkg/jobs/clean/cleaner.go
+++ b/pkg/jobs/clean/cleaner.go
@@ -104,7 +104,7 @@ func (c *Cleaner) webhookLogClean(ctx context.Context, current time.Time) {
 				common.OrderBy: "l.id",
 			},
 		}
-		webhooklogs, _, err := c.mgr.WebhookMgr.ListWebhookLogs(ctx, query, nil)
+		webhooklogs, err := c.mgr.WebhookMgr.ListWebhookLogsForClean(ctx, query)
 		if err != nil {
 			log.Errorf(ctx, "failed to list webhooklogs: %v", err)
 			time.Sleep(5 * time.Second)

--- a/pkg/jobs/clean/cleaner.go
+++ b/pkg/jobs/clean/cleaner.go
@@ -101,7 +101,6 @@ func (c *Cleaner) webhookLogClean(ctx context.Context, current time.Time) {
 			Keywords: q.KeyWords{
 				common.StartID: c.webhookLogCursor,
 				common.Limit:   c.Batch,
-				common.OrderBy: "l.id",
 			},
 		}
 		webhooklogs, err := c.mgr.WebhookMgr.ListWebhookLogsForClean(ctx, query)

--- a/pkg/webhook/dao/dao.go
+++ b/pkg/webhook/dao/dao.go
@@ -327,38 +327,22 @@ func (d *dao) GetMaxEventIDOfLog(ctx context.Context) (uint, error) {
 func (d *dao) ListWebhookLogsForClean(ctx context.Context, query *q.Query) ([]*models.WebhookLogWithEventInfo, error) {
 	var logs []*models.WebhookLogWithEventInfo
 
-	stm := d.db.WithContext(ctx).Table("tb_webhook_log l").
+	statement := d.db.WithContext(ctx).Table("tb_webhook_log l").
 		Joins("left join tb_event e on l.event_id=e.id").
 		Select("l.id, l.updated_at, e.resource_type, e.resource_id, e.event_type")
 
-	if query != nil && query.Keywords != nil {
-		for k, v := range query.Keywords {
-			switch k {
-			case common.Orphaned:
-				stm = stm.Where("e.id is null")
-			case common.WebhookID:
-				stm = stm.Where("l.webhook_id = ?", v)
-			case common.EventType:
-				stm = stm.Where("e.event_type = ?", v)
-			case common.Offset:
-				if offset, ok := v.(int); ok {
-					stm = stm.Offset(offset)
-				}
-			case common.Limit:
-				if limit, ok := v.(int); ok {
-					stm = stm.Limit(limit)
-				}
-			case common.StartID:
-				stm = stm.Where("l.id > ?", v)
-			case common.EndID:
-				stm = stm.Where("l.id <= ?", v)
-			case common.OrderBy:
-				stm = stm.Order(v)
+	if query != nil {
+		if v, ok := query.Keywords[common.StartID]; ok {
+			statement = statement.Where("created_at <= ?", v)
+		}
+		if v, ok := query.Keywords[common.Limit]; ok {
+			if limit, ok := v.(int); ok {
+				statement = statement.Limit(limit)
 			}
 		}
 	}
 
-	if result := stm.Find(&logs); result.Error != nil {
+	if result := statement.Find(&logs); result.Error != nil {
 		return nil, herrors.NewErrInsertFailed(herrors.WebhookLogInDB, result.Error.Error())
 	}
 

--- a/pkg/webhook/dao/dao.go
+++ b/pkg/webhook/dao/dao.go
@@ -189,7 +189,7 @@ func (d *dao) ListWebhookLogs(ctx context.Context, query *q.Query,
 			case common.Orphaned:
 				stm = stm.Where("e.id is null")
 			case common.WebhookID:
-				stm = stm.Where("l.l.webhook_id = ?", v)
+				stm = stm.Where("l.webhook_id = ?", v)
 			case common.EventType:
 				stm = stm.Where("e.event_type = ?", v)
 			case common.Offset:

--- a/pkg/webhook/dao/dao.go
+++ b/pkg/webhook/dao/dao.go
@@ -189,7 +189,7 @@ func (d *dao) ListWebhookLogs(ctx context.Context, query *q.Query,
 			case common.Orphaned:
 				stm = stm.Where("e.id is null")
 			case common.WebhookID:
-				stm = stm.Where("l.webhook_id = ?", v)
+				stm = stm.Where("l.l.webhook_id = ?", v)
 			case common.EventType:
 				stm = stm.Where("e.event_type = ?", v)
 			case common.Offset:
@@ -333,7 +333,7 @@ func (d *dao) ListWebhookLogsForClean(ctx context.Context, query *q.Query) ([]*m
 
 	if query != nil {
 		if v, ok := query.Keywords[common.StartID]; ok {
-			statement = statement.Where("created_at <= ?", v)
+			statement = statement.Where("l.id > ?", v)
 		}
 		if v, ok := query.Keywords[common.Limit]; ok {
 			if limit, ok := v.(int); ok {

--- a/pkg/webhook/manager/manager.go
+++ b/pkg/webhook/manager/manager.go
@@ -47,6 +47,7 @@ type Manager interface {
 	GetWebhookLogByEventID(ctx context.Context, webhookID, eventID uint) (*models.WebhookLog, error)
 	GetMaxEventIDOfLog(ctx context.Context) (uint, error)
 	DeleteWebhookLogs(ctx context.Context, id ...uint) (int64, error)
+	ListWebhookLogsForClean(ctx context.Context, query *q.Query) ([]*models.WebhookLogWithEventInfo, error)
 }
 
 type manager struct {
@@ -181,4 +182,13 @@ func (m *manager) ResendWebhook(ctx context.Context, id uint) (*models.WebhookLo
 
 func (m *manager) GetMaxEventIDOfLog(ctx context.Context) (uint, error) {
 	return m.dao.GetMaxEventIDOfLog(ctx)
+}
+
+func (m *manager) ListWebhookLogsForClean(
+	ctx context.Context,
+	query *q.Query,
+) ([]*models.WebhookLogWithEventInfo, error) {
+	const op = "webhook manager: list webhook logs for clean"
+	defer wlog.Start(ctx, op).StopPrint()
+	return m.dao.ListWebhookLogsForClean(ctx, query)
 }

--- a/pkg/webhook/manager/manager_test.go
+++ b/pkg/webhook/manager/manager_test.go
@@ -58,13 +58,16 @@ func Test(t *testing.T) {
 	_, count, err := mgr.ListWebhookOfResources(ctx, resources, q.New(q.KeyWords{
 		common.Enabled: true,
 	}))
+	assert.Nil(t, err)
 	assert.Equal(t, int64(1), count)
 
 	retrieveWebhooks, err := mgr.ListWebhooks(ctx)
+	assert.Nil(t, err)
 	assert.Equal(t, 1, len(retrieveWebhooks))
 
 	webhook.URL = "https://horizon.com"
 	retrieveWebhook, err = mgr.UpdateWebhook(ctx, webhook.ID, webhook)
+	assert.Nil(t, err)
 	assert.Equal(t, retrieveWebhook.ID, webhook.ID)
 	assert.Equal(t, retrieveWebhook.URL, "https://horizon.com")
 

--- a/pkg/webhook/manager/manager_test.go
+++ b/pkg/webhook/manager/manager_test.go
@@ -1,0 +1,138 @@
+// Copyright © 2023 Horizoncd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"context"
+	"github.com/horizoncd/horizon/core/common"
+	"github.com/horizoncd/horizon/lib/orm"
+	"github.com/horizoncd/horizon/lib/q"
+	eventmanageer "github.com/horizoncd/horizon/pkg/event/manager"
+	eventmodels "github.com/horizoncd/horizon/pkg/event/models"
+	webhookmodels "github.com/horizoncd/horizon/pkg/webhook/models"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+var (
+	db, _    = orm.NewSqliteDB("")
+	ctx      context.Context
+	mgr      = New(db)
+	eventMgr = eventmanageer.New(db)
+)
+
+func Test(t *testing.T) {
+	events := []*eventmodels.Event{
+		{
+			EventSummary: eventmodels.EventSummary{
+				ResourceType: common.ResourceCluster,
+				ResourceID:   1,
+				EventType:    eventmodels.ClusterCreated,
+			},
+			ReqID: "xxx",
+		},
+		{
+			EventSummary: eventmodels.EventSummary{
+				ResourceType: common.ResourceCluster,
+				ResourceID:   2,
+				EventType:    eventmodels.ClusterCreated,
+			},
+			ReqID: "xxx",
+		},
+	}
+	for _, e := range events {
+		_, err := eventMgr.CreateEvent(ctx, e)
+		assert.Nil(t, err)
+	}
+
+	webhookLogs := []*webhookmodels.WebhookLog{
+		{
+			WebhookID:       1,
+			EventID:         1,
+			URL:             "http://example.com",
+			RequestHeaders:  "Content-Type: application/json",
+			RequestData:     `{"key": "value"}`,
+			ResponseHeaders: "Content-Type: application/json",
+			ResponseBody:    `{"status": "ok"}`,
+			Status:          webhookmodels.StatusWaiting,
+			ErrorMessage:    "",
+		},
+		{
+			WebhookID:       2,
+			EventID:         2,
+			URL:             "http://example.com",
+			RequestHeaders:  "Content-Type: application/json",
+			RequestData:     `{"key": "value"}`,
+			ResponseHeaders: "Content-Type: application/json",
+			ResponseBody:    `{"status": "ok"}`,
+			Status:          webhookmodels.StatusSuccess,
+			ErrorMessage:    "",
+		},
+	}
+
+	for _, log := range webhookLogs {
+		_, err := mgr.CreateWebhookLog(ctx, log)
+		assert.Nil(t, err)
+	}
+
+	retrievedLog, err := mgr.GetWebhookLog(ctx, webhookLogs[0].ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, retrievedLog)
+	assert.Equal(t, retrievedLog.ID, webhookLogs[0].ID)
+
+	retrievedLog.Status = webhookmodels.StatusSuccess
+	updatedLog, err := mgr.UpdateWebhookLog(ctx, retrievedLog)
+	assert.Nil(t, err)
+	assert.NotNil(t, updatedLog)
+	assert.Equal(t, updatedLog.Status, webhookmodels.StatusSuccess)
+
+	query := &q.Query{}
+	logs, _, err := mgr.ListWebhookLogs(ctx, query, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, logs)
+	assert.GreaterOrEqual(t, len(logs), 2)
+
+	query = &q.Query{
+		Keywords: q.KeyWords{
+			common.StartID: 0,
+			common.Limit:   10,
+		},
+	}
+	cleanLogs, err := mgr.ListWebhookLogsForClean(ctx, query)
+	assert.Nil(t, err)
+	assert.NotNil(t, cleanLogs)
+	assert.GreaterOrEqual(t, len(cleanLogs), 2)
+	for _, log := range cleanLogs {
+		assert.Contains(t, []uint{1, 2}, log.ID)
+	}
+
+	for _, log := range webhookLogs {
+		_, err = mgr.DeleteWebhookLogs(ctx, log.ID)
+		assert.Nil(t, err)
+	}
+}
+
+func TestMain(m *testing.M) {
+	if err := db.AutoMigrate(&webhookmodels.WebhookLog{},
+		&webhookmodels.Webhook{}); err != nil {
+		panic(err)
+	}
+	if err := db.AutoMigrate(&eventmodels.Event{}); err != nil {
+		panic(err)
+	}
+	ctx = context.TODO()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
### Description of your changes

In the webhook log cleaner, the task is time consuming due to ListWebhookLogs needing to query count(*) with log details. This SQL statement is optimized to improve the query efficiency.

<!--

Briefly describe what this pull request does. We love pull requests that resolve an open Horizon issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Read and followed Horizon's [contribution process](https://github.com/horizoncd/horizon/CONTRIBUTING.md).
- [ ] Run `make build && make lint` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers'
attention to anything that needs special consideration.

-->
